### PR TITLE
Integration tests

### DIFF
--- a/.github/workflows/integration-test-images.yml
+++ b/.github/workflows/integration-test-images.yml
@@ -28,7 +28,7 @@ jobs:
         id: "tagName"
 
       - name: "Build Docker image"
-        run: "docker build --tag extdn/${{ matrix.actions-with-docker-image }}-action:${{ matrix.php-version }}-latest ${{ matrix.actions-with-docker-image }}/. -f Dockerfile:${{ matrix.php-version }}"
+        run: "docker build --tag extdn/${{ matrix.actions-with-docker-image }}-action:${{ matrix.php-version }}-latest ${{ matrix.actions-with-docker-image }}/. -f ${{ matrix.actions-with-docker-image }}/Dockerfile:${{ matrix.php-version }}"
 
       - name: "Docker Login"
         run: "echo ${{ secrets.DOCKER_PASSWORD }} | $(which docker) login --password-stdin --username ${{ env.DOCKER_USERNAME }}"

--- a/.github/workflows/integration-test-images.yml
+++ b/.github/workflows/integration-test-images.yml
@@ -1,6 +1,9 @@
 name: Build Integration Images
 
-on: [push]
+on:
+  push:
+    paths:
+      - 'magento-integration-tests/**'
 
 jobs:
   build:

--- a/.github/workflows/integration-test-images.yml
+++ b/.github/workflows/integration-test-images.yml
@@ -11,7 +11,9 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - ["7.2", "7.3", "7.4"]
+          - "7.2"
+          - "7.3"
+          - "7.4"
         actions-with-docker-image:
           - "magento-integration-tests"
     env:

--- a/.github/workflows/integration-test-images.yml
+++ b/.github/workflows/integration-test-images.yml
@@ -1,0 +1,44 @@
+name: Build Integration Images
+
+on: [push]
+
+jobs:
+  build:
+    name: "Build and deploy"
+
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        php-version:
+          - ["7.2", "7.3", "7.4"]
+        actions-with-docker-image:
+          - "magento-integration-tests"
+    env:
+      DOCKER_USERNAME: "extdn"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "Grab version number"
+        uses: "olegtarasov/get-tag@v1"
+        id: "tagName"
+
+      - name: "Build Docker image"
+        run: "docker build --tag extdn/${{ matrix.actions-with-docker-image }}-action:${{ matrix.php-version }}-latest ${{ matrix.actions-with-docker-image }}/. -f Dockerfile:${{ matrix.php-version }}"
+
+      - name: "Docker Login"
+        run: "echo ${{ secrets.DOCKER_PASSWORD }} | $(which docker) login --password-stdin --username ${{ env.DOCKER_USERNAME }}"
+
+      - name: "Push Docker image (latest)"
+        run: "docker push extdn/${{ matrix.actions-with-docker-image }}-action:${{ matrix.php-version }}-latest"
+
+      #- name: "Tag Docker image (versioned)"
+      #  run: "docker tag extdn/${{ matrix.actions-with-docker-image }}-action extdn/${{ matrix.actions-with-docker-image }}-action:${{ steps.tagName.outputs.tag }}"
+
+      #- name: "Push Docker image (versioned)"
+      #  run: "docker push extdn/${{ matrix.actions-with-docker-image }}-action:${{ steps.tagName.outputs.tag }}"
+
+      - name: "Docker Logout"
+        run: "docker logout"

--- a/install-m2-from-mirror/dist/index.js
+++ b/install-m2-from-mirror/dist/index.js
@@ -964,7 +964,7 @@ async function run() {
 try { 
     const ceversion = core.getInput('ce-version');
     const options = {};
-    await exec.exec(`composer create-project --repository-url==https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${ceversion} m2-folder --no-install --no-interaction`);
+    await exec.exec(`composer create-project --repository-url=https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${ceversion} m2-folder --no-install --no-interaction`);
     options.cwd = './m2-folder';
     await exec.exec('composer', ['config', '--unset', 'repo.0'], options);
     await exec.exec('composer', ['config', 'repositories.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);

--- a/install-m2-from-mirror/dist/index.js
+++ b/install-m2-from-mirror/dist/index.js
@@ -967,7 +967,7 @@ try {
     await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${ceversion} m2-folder --no-install --no-interaction`);
     options.cwd = './m2-folder';
     await exec.exec('composer', ['config', '--unset', 'repo.0'], options);
-    await exec.exec('composer', ['config', 'repo.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);
+    await exec.exec('composer', ['config', 'repositories.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);
     await exec.exec('composer', ['install', '--prefer-dist'], options);
 
     await exec.exec('bin/magento', 

--- a/install-m2-from-mirror/dist/index.js
+++ b/install-m2-from-mirror/dist/index.js
@@ -964,7 +964,7 @@ async function run() {
 try { 
     const ceversion = core.getInput('ce-version');
     const options = {};
-    await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-custom-installers magento/project-community-edition m2-folder ${ceversion}`);
+    await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-plugins magento/project-community-edition m2-folder ${ceversion}`);
     options.cwd = './m2-folder';
     await exec.exec('composer', ['config', '--unset', 'repo.0'], options);
     await exec.exec('composer', ['config', 'repositories.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);

--- a/install-m2-from-mirror/dist/index.js
+++ b/install-m2-from-mirror/dist/index.js
@@ -964,7 +964,7 @@ async function run() {
 try { 
     const ceversion = core.getInput('ce-version');
     const options = {};
-    await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${ceversion} m2-folder --no-install --no-interaction`);
+    await exec.exec(`composer create-project --repository-url==https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${ceversion} m2-folder --no-install --no-interaction`);
     options.cwd = './m2-folder';
     await exec.exec('composer', ['config', '--unset', 'repo.0'], options);
     await exec.exec('composer', ['config', 'repositories.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);

--- a/install-m2-from-mirror/dist/index.js
+++ b/install-m2-from-mirror/dist/index.js
@@ -964,7 +964,7 @@ async function run() {
 try { 
     const ceversion = core.getInput('ce-version');
     const options = {};
-    await exec.exec(`composer create-project --repository-url=https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${ceversion} m2-folder --no-install --no-interaction`);
+    await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-custom-installers magento/project-community-edition m2-folder ${ceversion}`);
     options.cwd = './m2-folder';
     await exec.exec('composer', ['config', '--unset', 'repo.0'], options);
     await exec.exec('composer', ['config', 'repositories.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);

--- a/install-m2-from-mirror/index.js
+++ b/install-m2-from-mirror/index.js
@@ -5,7 +5,7 @@ async function run() {
 try { 
     const ceversion = core.getInput('ce-version');
     const options = {};
-    await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${ceversion} m2-folder --no-install --no-interaction`);
+    await exec.exec(`composer create-project --repository-url==https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${ceversion} m2-folder --no-install --no-interaction`);
     options.cwd = './m2-folder';
     await exec.exec('composer', ['config', '--unset', 'repo.0'], options);
     await exec.exec('composer', ['config', 'repositories.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);

--- a/install-m2-from-mirror/index.js
+++ b/install-m2-from-mirror/index.js
@@ -5,7 +5,7 @@ async function run() {
 try { 
     const ceversion = core.getInput('ce-version');
     const options = {};
-    await exec.exec(`composer create-project --repository-url=https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${ceversion} m2-folder --no-install --no-interaction`);
+    await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-custom-installers magento/project-community-edition m2-folder ${ceversion}`);
     options.cwd = './m2-folder';
     await exec.exec('composer', ['config', '--unset', 'repo.0'], options);
     await exec.exec('composer', ['config', 'repositories.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);

--- a/install-m2-from-mirror/index.js
+++ b/install-m2-from-mirror/index.js
@@ -5,7 +5,7 @@ async function run() {
 try { 
     const ceversion = core.getInput('ce-version');
     const options = {};
-    await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-custom-installers magento/project-community-edition m2-folder ${ceversion}`);
+    await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-plugins magento/project-community-edition m2-folder ${ceversion}`);
     options.cwd = './m2-folder';
     await exec.exec('composer', ['config', '--unset', 'repo.0'], options);
     await exec.exec('composer', ['config', 'repositories.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);

--- a/install-m2-from-mirror/index.js
+++ b/install-m2-from-mirror/index.js
@@ -5,7 +5,7 @@ async function run() {
 try { 
     const ceversion = core.getInput('ce-version');
     const options = {};
-    await exec.exec(`composer create-project --repository-url==https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${ceversion} m2-folder --no-install --no-interaction`);
+    await exec.exec(`composer create-project --repository-url=https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${ceversion} m2-folder --no-install --no-interaction`);
     options.cwd = './m2-folder';
     await exec.exec('composer', ['config', '--unset', 'repo.0'], options);
     await exec.exec('composer', ['config', 'repositories.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);

--- a/install-m2-from-mirror/index.js
+++ b/install-m2-from-mirror/index.js
@@ -8,7 +8,7 @@ try {
     await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${ceversion} m2-folder --no-install --no-interaction`);
     options.cwd = './m2-folder';
     await exec.exec('composer', ['config', '--unset', 'repo.0'], options);
-    await exec.exec('composer', ['config', 'repo.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);
+    await exec.exec('composer', ['config', 'repositories.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);
     await exec.exec('composer', ['install', '--prefer-dist'], options);
 
     await exec.exec('bin/magento', 

--- a/magento-integration-tests/7.2/action.yml
+++ b/magento-integration-tests/7.2/action.yml
@@ -28,6 +28,7 @@ runs:
     MODULE_NAME: ${{ inputs.module_name }}
     COMPOSER_NAME: ${{ inputs.composer_name }}
     MAGENTO_VERSION: ${{ inputs.ce_version }}
+    COMPOSER_MEMORY_LIMIT: -1
 
 branding:
   icon: 'code'  

--- a/magento-integration-tests/7.2/action.yml
+++ b/magento-integration-tests/7.2/action.yml
@@ -11,11 +11,7 @@ inputs:
   ce_version:
     description: 'Magento 2 Open Source version number'
     required: true
-    default: '2.4.0'
-  php_version:
-    description: 'Php version number'
-    required: true
-    default: '7.4'
+    default: '2.3.5-p2'
   module_source:
     description: 'Relative path to your module source within your repository. Empty by default.'
     required: false
@@ -27,7 +23,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://extdn/magento-integration-tests-action:7.4-latest'
+  image: 'docker://extdn/magento-integration-tests-action:7.2-latest'
   env:
     MODULE_NAME: ${{ inputs.module_name }}
     COMPOSER_NAME: ${{ inputs.composer_name }}

--- a/magento-integration-tests/7.3/action.yml
+++ b/magento-integration-tests/7.3/action.yml
@@ -28,6 +28,7 @@ runs:
     MODULE_NAME: ${{ inputs.module_name }}
     COMPOSER_NAME: ${{ inputs.composer_name }}
     MAGENTO_VERSION: ${{ inputs.ce_version }}
+    COMPOSER_MEMORY_LIMIT: -1
 
 branding:
   icon: 'code'  

--- a/magento-integration-tests/7.3/action.yml
+++ b/magento-integration-tests/7.3/action.yml
@@ -1,0 +1,35 @@
+name: 'Magento 2 integration tests'
+author: 'ExtDN'
+description: 'runs integration tests for given Magento 2 open source version'
+inputs:
+  module_name:
+    description: 'Your Magento module name. Example: Foo_Bar'
+    required: true
+  composer_name:
+    description: 'Your composer name. Example: foo/magento2-bar'
+    required: true
+  ce_version:
+    description: 'Magento 2 Open Source version number'
+    required: true
+    default: '2.4.0'
+  module_source:
+    description: 'Relative path to your module source within your repository. Empty by default.'
+    required: false
+  phpunit_file:
+    description: 'Relative path to your own PHPUnit file. Leave empty to use the default.'
+    required: false
+  magento_pre_install_script:
+    description: 'Relative path to an optional script before Magento installation is run. Leave empty to use the default.'
+    required: false
+runs:
+  using: 'docker'
+  image: 'docker://extdn/magento-integration-tests-action:7.3-latest'
+  env:
+    MODULE_NAME: ${{ inputs.module_name }}
+    COMPOSER_NAME: ${{ inputs.composer_name }}
+    MAGENTO_VERSION: ${{ inputs.ce_version }}
+
+branding:
+  icon: 'code'  
+  color: 'green'
+

--- a/magento-integration-tests/7.4/action.yml
+++ b/magento-integration-tests/7.4/action.yml
@@ -28,6 +28,7 @@ runs:
     MODULE_NAME: ${{ inputs.module_name }}
     COMPOSER_NAME: ${{ inputs.composer_name }}
     MAGENTO_VERSION: ${{ inputs.ce_version }}
+    COMPOSER_MEMORY_LIMIT: -1
 
 branding:
   icon: 'code'  

--- a/magento-integration-tests/7.4/action.yml
+++ b/magento-integration-tests/7.4/action.yml
@@ -1,0 +1,35 @@
+name: 'Magento 2 integration tests'
+author: 'ExtDN'
+description: 'runs integration tests for given Magento 2 open source version'
+inputs:
+  module_name:
+    description: 'Your Magento module name. Example: Foo_Bar'
+    required: true
+  composer_name:
+    description: 'Your composer name. Example: foo/magento2-bar'
+    required: true
+  ce_version:
+    description: 'Magento 2 Open Source version number'
+    required: true
+    default: '2.4.0'
+  module_source:
+    description: 'Relative path to your module source within your repository. Empty by default.'
+    required: false
+  phpunit_file:
+    description: 'Relative path to your own PHPUnit file. Leave empty to use the default.'
+    required: false
+  magento_pre_install_script:
+    description: 'Relative path to an optional script before Magento installation is run. Leave empty to use the default.'
+    required: false
+runs:
+  using: 'docker'
+  image: 'docker://extdn/magento-integration-tests-action:7.4-latest'
+  env:
+    MODULE_NAME: ${{ inputs.module_name }}
+    COMPOSER_NAME: ${{ inputs.composer_name }}
+    MAGENTO_VERSION: ${{ inputs.ce_version }}
+
+branding:
+  icon: 'code'  
+  color: 'green'
+

--- a/magento-integration-tests/Dockerfile:7.2
+++ b/magento-integration-tests/Dockerfile:7.2
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     git \
     zlib1g-dev \
     zip \
+    unzip \
     libjpeg62-turbo-dev \
     libfreetype6-dev \
     libzip-dev \

--- a/magento-integration-tests/Dockerfile:7.2
+++ b/magento-integration-tests/Dockerfile:7.2
@@ -1,4 +1,4 @@
-FROM php:7.2
+FROM php:7.2-cli
 
 COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
 

--- a/magento-integration-tests/Dockerfile:7.2
+++ b/magento-integration-tests/Dockerfile:7.2
@@ -2,7 +2,7 @@ FROM php:7.2-cli
 
 COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update && apt-get -y install \
+RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \
     apt-transport-https \
     git \
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get -y install \
     libicu-dev \
     libxml2-dev \
     libxslt-dev \
-    netcat
+    netcat \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-install pdo pdo_mysql
 RUN docker-php-ext-install xsl

--- a/magento-integration-tests/Dockerfile:7.2
+++ b/magento-integration-tests/Dockerfile:7.2
@@ -32,12 +32,12 @@ RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install sockets
 RUN composer global require hirak/prestissimo
-RUN apt-get clean
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
 
 COPY docker-files /docker-files
+RUN echo 'memory_limit = -1' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
 

--- a/magento-integration-tests/Dockerfile:7.3
+++ b/magento-integration-tests/Dockerfile:7.3
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     git \
     zlib1g-dev \
     zip \
+    unzip \
     libjpeg62-turbo-dev \
     libfreetype6-dev \
     libzip-dev \

--- a/magento-integration-tests/Dockerfile:7.3
+++ b/magento-integration-tests/Dockerfile:7.3
@@ -1,4 +1,4 @@
-FROM php:7.3
+FROM php:7.3-cli
 
 COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
 

--- a/magento-integration-tests/Dockerfile:7.3
+++ b/magento-integration-tests/Dockerfile:7.3
@@ -2,7 +2,7 @@ FROM php:7.3-cli
 
 COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update && apt-get -y install \
+RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \
     apt-transport-https \
     git \
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get -y install \
     libicu-dev \
     libxml2-dev \
     libxslt-dev \
-    netcat
+    netcat \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-install pdo pdo_mysql
 RUN docker-php-ext-install xsl

--- a/magento-integration-tests/Dockerfile:7.3
+++ b/magento-integration-tests/Dockerfile:7.3
@@ -32,12 +32,12 @@ RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install sockets
 RUN composer global require hirak/prestissimo
-RUN apt-get clean
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
 
 COPY docker-files /docker-files
+RUN echo 'memory_limit = -1' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
 

--- a/magento-integration-tests/Dockerfile:7.4
+++ b/magento-integration-tests/Dockerfile:7.4
@@ -2,7 +2,7 @@ FROM php:7.4-cli
 
 COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update && apt-get -y install \
+RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \
     apt-transport-https \
     git \
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get -y install \
     libicu-dev \
     libxml2-dev \
     libxslt-dev \
-    netcat
+    netcat \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-install pdo pdo_mysql
 RUN docker-php-ext-install xsl

--- a/magento-integration-tests/Dockerfile:7.4
+++ b/magento-integration-tests/Dockerfile:7.4
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     git \
     zlib1g-dev \
     zip \
+    unzip \
     libjpeg62-turbo-dev \
     libfreetype6-dev \
     libzip-dev \

--- a/magento-integration-tests/Dockerfile:7.4
+++ b/magento-integration-tests/Dockerfile:7.4
@@ -32,12 +32,12 @@ RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install sockets
 RUN composer global require hirak/prestissimo
-RUN apt-get clean
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
 
 COPY docker-files /docker-files
+RUN echo 'memory_limit = -1' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
 

--- a/magento-integration-tests/Dockerfile:7.4
+++ b/magento-integration-tests/Dockerfile:7.4
@@ -1,4 +1,4 @@
-FROM php:7.4
+FROM php:7.4-cli
 
 COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
 

--- a/magento-integration-tests/README.md
+++ b/magento-integration-tests/README.md
@@ -13,12 +13,11 @@ jobs:
         image: mysql:5.7
         env:
           MYSQL_ROOT_PASSWORD: root
-          MYSQL_SQL_TO_RUN: 'GRANT ALL ON *.* TO "root"@"%";'
         ports:
           - 3306:3306
         options: --tmpfs /tmp:rw --tmpfs /var/lib/mysql:rw --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       es:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0
+        image: docker.io/wardenenv/elasticsearch:7.8
         ports:
           - 9200:9200
         env:

--- a/magento-integration-tests/action.yml
+++ b/magento-integration-tests/action.yml
@@ -29,11 +29,11 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:${{ inputs.php_version }}-latest'
   args:
-    - "-e MAGENTO_MARKETPLACE_USERNAME=${{ secrets.MAGENTO_MARKETPLACE_USERNAME }}"
-    - "-e MAGENTO_MARKETPLACE_PASSWORD=${{ secrets.MAGENTO_MARKETPLACE_PASSWORD }}"
-    - "-e MODULE_NAME=${{ inputs.module_name }}"
-    - "-e COMPOSER_NAME=${{ inputs.composer_name }}"
-    - "-e MAGENTO_VERSION=${{ inputs.ce_version }}"
+    - "-e MAGENTO_MARKETPLACE_USERNAME="${{ env.MAGENTO_MARKETPLACE_USERNAME }}
+    - "-e MAGENTO_MARKETPLACE_PASSWORD="${{ env.MAGENTO_MARKETPLACE_PASSWORD }}
+    - "-e MODULE_NAME="${{ inputs.module_name }}
+    - "-e COMPOSER_NAME="${{ inputs.composer_name }}
+    - "-e MAGENTO_VERSION="${{ inputs.ce_version }}
 
 branding:
   icon: 'code'  

--- a/magento-integration-tests/action.yml
+++ b/magento-integration-tests/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://extdn/magento-integration-tests-action:${{ inputs.php_version }}-latest'
+  image: 'docker://extdn/magento-integration-tests-action:7.4-latest'
   env:
     MAGENTO_MARKETPLACE_USERNAME: ${{ secret.MAGENTO_MARKETPLACE_USERNAME }}
     MAGENTO_MARKETPLACE_PASSWORD: ${{ secret.MAGENTO_MARKETPLACE_PASSWORD }}

--- a/magento-integration-tests/action.yml
+++ b/magento-integration-tests/action.yml
@@ -28,12 +28,12 @@ inputs:
 runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:${{ inputs.php_version }}-latest'
-  args:
-    - "-e MAGENTO_MARKETPLACE_USERNAME="${{ env.MAGENTO_MARKETPLACE_USERNAME }}
-    - "-e MAGENTO_MARKETPLACE_PASSWORD="${{ env.MAGENTO_MARKETPLACE_PASSWORD }}
-    - "-e MODULE_NAME="${{ inputs.module_name }}
-    - "-e COMPOSER_NAME="${{ inputs.composer_name }}
-    - "-e MAGENTO_VERSION="${{ inputs.ce_version }}
+  env:
+    MAGENTO_MARKETPLACE_USERNAME: ${{ env.MAGENTO_MARKETPLACE_USERNAME }}
+    MAGENTO_MARKETPLACE_PASSWORD: ${{ env.MAGENTO_MARKETPLACE_PASSWORD }}
+    MODULE_NAME: ${{ inputs.module_name }}
+    COMPOSER_NAME: ${{ inputs.composer_name }}
+    MAGENTO_VERSION: ${{ inputs.ce_version }}
 
 branding:
   icon: 'code'  

--- a/magento-integration-tests/action.yml
+++ b/magento-integration-tests/action.yml
@@ -29,8 +29,6 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:7.4-latest'
   env:
-    MAGENTO_MARKETPLACE_USERNAME: ${{ env.MAGENTO_MARKETPLACE_USERNAME }}
-    MAGENTO_MARKETPLACE_PASSWORD: ${{ env.MAGENTO_MARKETPLACE_PASSWORD }}
     MODULE_NAME: ${{ inputs.module_name }}
     COMPOSER_NAME: ${{ inputs.composer_name }}
     MAGENTO_VERSION: ${{ inputs.ce_version }}

--- a/magento-integration-tests/action.yml
+++ b/magento-integration-tests/action.yml
@@ -28,6 +28,13 @@ inputs:
 runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:${{ inputs.php_version }}-latest'
+  args:
+    - "-e MAGENTO_MARKETPLACE_USERNAME=${{ secrets.MAGENTO_MARKETPLACE_USERNAME }}"
+    - "-e MAGENTO_MARKETPLACE_PASSWORD=${{ secrets.MAGENTO_MARKETPLACE_PASSWORD }}"
+    - "-e MODULE_NAME=${{ inputs.module_name }}"
+    - "-e COMPOSER_NAME=${{ inputs.composer_name }}"
+    - "-e MAGENTO_VERSION=${{ inputs.ce_version }}"
+
 branding:
   icon: 'code'  
   color: 'green'

--- a/magento-integration-tests/action.yml
+++ b/magento-integration-tests/action.yml
@@ -29,8 +29,8 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:7.4-latest'
   env:
-    MAGENTO_MARKETPLACE_USERNAME: ${{ secret.MAGENTO_MARKETPLACE_USERNAME }}
-    MAGENTO_MARKETPLACE_PASSWORD: ${{ secret.MAGENTO_MARKETPLACE_PASSWORD }}
+    MAGENTO_MARKETPLACE_USERNAME: ${{ env.MAGENTO_MARKETPLACE_USERNAME }}
+    MAGENTO_MARKETPLACE_PASSWORD: ${{ env.MAGENTO_MARKETPLACE_PASSWORD }}
     MODULE_NAME: ${{ inputs.module_name }}
     COMPOSER_NAME: ${{ inputs.composer_name }}
     MAGENTO_VERSION: ${{ inputs.ce_version }}

--- a/magento-integration-tests/action.yml
+++ b/magento-integration-tests/action.yml
@@ -29,8 +29,8 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:${{ inputs.php_version }}-latest'
   env:
-    MAGENTO_MARKETPLACE_USERNAME: ${{ env.MAGENTO_MARKETPLACE_USERNAME }}
-    MAGENTO_MARKETPLACE_PASSWORD: ${{ env.MAGENTO_MARKETPLACE_PASSWORD }}
+    MAGENTO_MARKETPLACE_USERNAME: ${{ secret.MAGENTO_MARKETPLACE_USERNAME }}
+    MAGENTO_MARKETPLACE_PASSWORD: ${{ secret.MAGENTO_MARKETPLACE_PASSWORD }}
     MODULE_NAME: ${{ inputs.module_name }}
     COMPOSER_NAME: ${{ inputs.composer_name }}
     MAGENTO_VERSION: ${{ inputs.ce_version }}

--- a/magento-integration-tests/action.yml
+++ b/magento-integration-tests/action.yml
@@ -11,16 +11,23 @@ inputs:
   ce_version:
     description: 'Magento 2 Open Source version number'
     required: true
-    default: '2.3.5'
+    default: '2.4.0'
+  php_version:
+    description: 'Php version number'
+    required: true
+    default: '7.4'
   module_source:
     description: 'Relative path to your module source within your repository. Empty by default.'
+    required: false
   phpunit_file:
     description: 'Relative path to your own PHPUnit file. Leave empty to use the default.'
+    required: false
   magento_pre_install_script:
     description: 'Relative path to an optional script before Magento installation is run. Leave empty to use the default.'
+    required: false
 runs:
   using: 'docker'
-  image: 'docker://yireo/github-actions-magento-integration-tests:latest'
+  image: 'docker://extdn/magento-integration-tests-action:${{ inputs.php_version }}-latest'
 branding:
   icon: 'code'  
   color: 'green'

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -23,11 +23,6 @@ PROJECT_PATH=$GITHUB_WORKSPACE
 
 echo "MySQL checks"
 nc -z -w1 mysql 3306 || (echo "MySQL is not running" && exit)
-php /docker-files/db-create-and-test.php magento2 || exit
-php /docker-files/db-create-and-test.php magento2test || exit
-
-echo "Setup Magento credentials"
-composer global require hirak/prestissimo
 
 echo "Prepare composer installation for $MAGENTO_VERSION"
 composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-custom-installers magento/project-community-edition $MAGENTO_ROOT "$MAGENTO_VERSION"
@@ -60,6 +55,10 @@ composer install --no-interaction --no-progress --no-suggest
 if [[ "$MAGENTO_VERSION" == "2.3.4" ]]; then
     # Somebody hacked the Magento\Setup\Controller\Landing.php file to add Laminas MVC which is not installed in 2.3.4
     curl -s https://gist.githubusercontent.com/jissereitsma/51742489c6e97138363c93983a034af2/raw/1f14af19a64195b1246263513aba594726e5d72a/remove-laminas-from-setup-landing-controller.patch | patch -p0
+fi
+if [[ "$MAGENTO_VERSION" == "2.3.4" ]]; then
+  #Dotdigital tests don't work out of the box
+  rm -rf "$MAGENTO_ROOT/vendor/dotmailer/dotmailer-magento2-extension/Test/Integration/"
 fi
 
 echo "Gathering specific Magento setup options"

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -30,7 +30,7 @@ echo "Setup Magento credentials"
 composer global require hirak/prestissimo
 
 echo "Prepare composer installation for $MAGENTO_VERSION"
-COMPOSER_MEMORY_LIMIT=8G composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-custom-installers magento/project-community-edition $MAGENTO_ROOT "$MAGENTO_VERSION"
+composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-custom-installers magento/project-community-edition $MAGENTO_ROOT "$MAGENTO_VERSION"
 
 echo "Setup extension source folder within Magento root"
 cd $MAGENTO_ROOT
@@ -55,7 +55,7 @@ if [[ ! -z "$INPUT_MAGENTO_PRE_INSTALL_SCRIPT" && -f "${GITHUB_WORKSPACE}/$INPUT
 fi
 
 echo "Run installation"
-COMPOSER_MEMORY_LIMIT=8G composer install --no-interaction --no-progress --no-suggest
+composer install --no-interaction --no-progress --no-suggest
 
 if [[ "$MAGENTO_VERSION" == "2.3.4" ]]; then
     # Somebody hacked the Magento\Setup\Controller\Landing.php file to add Laminas MVC which is not installed in 2.3.4
@@ -79,7 +79,7 @@ if [[ "$ELASTICSEARCH" == "1" ]]; then
 fi
 
 echo "Run Magento setup: $SETUP_ARGS"
-php -d memory_limit=8G bin/magento setup:install $SETUP_ARGS
+php bin/magento setup:install $SETUP_ARGS
 
 cd $MAGENTO_ROOT
 if [[ ! -z "$MODULE_NAME" ]] ; then

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -25,7 +25,7 @@ echo "MySQL checks"
 nc -z -w1 mysql 3306 || (echo "MySQL is not running" && exit)
 
 echo "Prepare composer installation for $MAGENTO_VERSION"
-composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-custom-installers magento/project-community-edition $MAGENTO_ROOT "$MAGENTO_VERSION"
+composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-plugins magento/project-community-edition $MAGENTO_ROOT "$MAGENTO_VERSION"
 
 echo "Setup extension source folder within Magento root"
 cd $MAGENTO_ROOT

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -30,7 +30,7 @@ echo "Setup Magento credentials"
 composer global require hirak/prestissimo
 
 echo "Prepare composer installation for $MAGENTO_VERSION"
-COMPOSER_MEMORY_LIMIT=8G composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${MAGENTO_VERSION} $MAGENTO_ROOT --no-install --no-interaction --no-progress
+COMPOSER_MEMORY_LIMIT=8G composer create-project --repository-url==https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${MAGENTO_VERSION} $MAGENTO_ROOT --no-install --no-interaction --no-progress
 
 echo "Setup extension source folder within Magento root"
 cd $MAGENTO_ROOT

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -58,7 +58,7 @@ if [[ "$MAGENTO_VERSION" == "2.3.4" ]]; then
     # Somebody hacked the Magento\Setup\Controller\Landing.php file to add Laminas MVC which is not installed in 2.3.4
     curl -s https://gist.githubusercontent.com/jissereitsma/51742489c6e97138363c93983a034af2/raw/1f14af19a64195b1246263513aba594726e5d72a/remove-laminas-from-setup-landing-controller.patch | patch -p0
 fi
-if [[ "$MAGENTO_VERSION" == "2.3.4" ]]; then
+if [[ "$MAGENTO_VERSION" == "2.4.0" ]]; then
   #Dotdigital tests don't work out of the box
   rm -rf "$MAGENTO_ROOT/vendor/dotmailer/dotmailer-magento2-extension/Test/Integration/"
 fi

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -82,12 +82,13 @@ fi
 echo "Run Magento setup: $SETUP_ARGS"
 php bin/magento setup:install $SETUP_ARGS
 
-cd $MAGENTO_ROOT
-if [[ ! -z "$MODULE_NAME" ]] ; then
-    echo "Enable the module"
-    bin/magento module:enable ${MODULE_NAME}
-    bin/magento setup:db:status -q || bin/magento setup:upgrade
-fi
+# Not required as done as part of setup:install
+#cd $MAGENTO_ROOT
+#if [[ ! -z "$MODULE_NAME" ]] ; then
+#    echo "Enable the module"
+#    bin/magento module:enable ${MODULE_NAME}
+#    bin/magento setup:db:status -q || bin/magento setup:upgrade
+#fi
 
 echo "Trying phpunit.xml file $PHPUNIT_FILE"
 if [[ ! -z "$PHPUNIT_FILE" ]] ; then

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -30,7 +30,7 @@ echo "Setup Magento credentials"
 composer global require hirak/prestissimo
 
 echo "Prepare composer installation for $MAGENTO_VERSION"
-COMPOSER_MEMORY_LIMIT=8G composer create-project --repository-url==https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${MAGENTO_VERSION} $MAGENTO_ROOT --no-install --no-progress
+COMPOSER_MEMORY_LIMIT=8G composer create-project --repository-url=https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${MAGENTO_VERSION} $MAGENTO_ROOT --no-install --no-progress
 
 echo "Setup extension source folder within Magento root"
 cd $MAGENTO_ROOT

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -30,7 +30,7 @@ echo "Setup Magento credentials"
 composer global require hirak/prestissimo
 
 echo "Prepare composer installation for $MAGENTO_VERSION"
-COMPOSER_MEMORY_LIMIT=8G composer create-project --repository-url==https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${MAGENTO_VERSION} $MAGENTO_ROOT --no-install --no-interaction --no-progress
+COMPOSER_MEMORY_LIMIT=8G composer create-project --repository-url==https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${MAGENTO_VERSION} $MAGENTO_ROOT --no-install --no-progress
 
 echo "Setup extension source folder within Magento root"
 cd $MAGENTO_ROOT

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -30,7 +30,7 @@ echo "Setup Magento credentials"
 composer global require hirak/prestissimo
 
 echo "Prepare composer installation for $MAGENTO_VERSION"
-COMPOSER_MEMORY_LIMIT=8G composer create-project --repository-url=https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${MAGENTO_VERSION} $MAGENTO_ROOT --no-install --no-progress
+COMPOSER_MEMORY_LIMIT=8G composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-custom-installers magento/project-community-edition m2 "$MAGENTO_VERSION"
 
 echo "Setup extension source folder within Magento root"
 cd $MAGENTO_ROOT

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -35,9 +35,10 @@ mkdir -p local-source/
 cd local-source/
 cp -R ${GITHUB_WORKSPACE}/${MODULE_SOURCE} $GITHUB_ACTION
 
-echo "Removing unneeded packages"
-composer require yireo/magento2-replace-bundled:4.0.3 --no-update --no-interaction
-composer require yireo/magento2-replace-sample-data --no-update --no-interaction
+#echo "Removing unneeded packages"
+# can move to pre-install scripts if needed?
+#composer require yireo/magento2-replace-bundled:4.0.3 --no-update --no-interaction
+#composer require yireo/magento2-replace-sample-data --no-update --no-interaction
 
 echo "Configure extension source in composer"
 cd $MAGENTO_ROOT

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -17,8 +17,6 @@ fi
 test -z "${MODULE_NAME}" && (echo "'module_name' is not set in your GitHub Actions YAML file")
 test -z "${COMPOSER_NAME}" && (echo "'composer_name' is not set in your GitHub Actions YAML file" && exit 1)
 test -z "${MAGENTO_VERSION}" && (echo "'ce_version' is not set in your GitHub Actions YAML file" && exit 1)
-test -z "${MAGENTO_MARKETPLACE_USERNAME}" && (echo "'MAGENTO_MARKETPLACE_USERNAME' is not available as a secret" && exit 1)
-test -z "${MAGENTO_MARKETPLACE_PASSWORD}" && (echo "'MAGENTO_MARKETPLACE_PASSWORD' is not available as a secret" && exit 1)
 
 MAGENTO_ROOT=/tmp/m2
 PROJECT_PATH=$GITHUB_WORKSPACE
@@ -30,10 +28,9 @@ php /docker-files/db-create-and-test.php magento2test || exit
 
 echo "Setup Magento credentials"
 composer global require hirak/prestissimo
-composer global config http-basic.repo.magento.com "$MAGENTO_MARKETPLACE_USERNAME" "$MAGENTO_MARKETPLACE_PASSWORD"
 
 echo "Prepare composer installation for $MAGENTO_VERSION"
-COMPOSER_MEMORY_LIMIT=8G composer create-project --repository=https://repo.magento.com/ magento/project-community-edition:${MAGENTO_VERSION} $MAGENTO_ROOT --no-install --no-interaction --no-progress
+COMPOSER_MEMORY_LIMIT=8G composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ magento/project-community-edition:${MAGENTO_VERSION} $MAGENTO_ROOT --no-install --no-interaction --no-progress
 
 echo "Setup extension source folder within Magento root"
 cd $MAGENTO_ROOT
@@ -47,6 +44,8 @@ composer require yireo/magento2-replace-sample-data --no-update --no-interaction
 
 echo "Configure extension source in composer"
 cd $MAGENTO_ROOT
+composer config --unset repo.0
+composer config repositories.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
 composer config repositories.local-source path local-source/\*
 composer require $COMPOSER_NAME:@dev --no-update --no-interaction
 

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -23,6 +23,8 @@ PROJECT_PATH=$GITHUB_WORKSPACE
 
 echo "MySQL checks"
 nc -z -w1 mysql 3306 || (echo "MySQL is not running" && exit)
+php /docker-files/db-create-and-test.php magento2 || exit
+php /docker-files/db-create-and-test.php magento2test || exit
 
 echo "Prepare composer installation for $MAGENTO_VERSION"
 composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-plugins magento/project-community-edition $MAGENTO_ROOT "$MAGENTO_VERSION"

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -30,7 +30,7 @@ echo "Setup Magento credentials"
 composer global require hirak/prestissimo
 
 echo "Prepare composer installation for $MAGENTO_VERSION"
-COMPOSER_MEMORY_LIMIT=8G composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-custom-installers magento/project-community-edition m2 "$MAGENTO_VERSION"
+COMPOSER_MEMORY_LIMIT=8G composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-custom-installers magento/project-community-edition $MAGENTO_ROOT "$MAGENTO_VERSION"
 
 echo "Setup extension source folder within Magento root"
 cd $MAGENTO_ROOT


### PR DESCRIPTION
@jissereitsma I have made some further changes to the integration tests, mostly triggered by myself not being able to run them on Magento 2.4.0.

Notable changes:
- main invocation is now via a github action (which in turn uses the docker image) rather than straight to using docker. 
- images are now built automatically and pushed to https://hub.docker.com/r/extdn/magento-integration-tests-action/tags via  https://github.com/extdn/github-actions-m2/compare/integration-tests?expand=1#diff-c2141bf18100b64b63345d9e0d819f2c
- To make usage easier I have also switched to using the authentication less mirror of repo.magento.com that I set up
- Updated the elasticsearch config (taken from the warden project) that worked in my testing

Note to self - this https://github.com/extdn/github-actions-m2/compare/integration-tests?expand=1#diff-395968bd9d775aea5c3de377c12df479R31 needs to be updated to master for merging