### PR TITLE
Add new 2.4.3 config option

### DIFF
--- a/magento-integration-tests/docker-files/phpunit.xml
+++ b/magento-integration-tests/docker-files/phpunit.xml
@@ -30,6 +30,7 @@
         <ini name="xdebug.max_nesting_level" value="200"/>
         <ini name="memory_limit" value="-1"/>
         <const name="TESTS_INSTALL_CONFIG_FILE" value="etc/install-config-mysql.php"/>
+        <const name="TESTS_POST_INSTALL_SETUP_COMMAND_CONFIG_FILE" value="etc/post-install-setup-command-config.php"/>
         <const name="TESTS_GLOBAL_CONFIG_FILE" value="etc/config-global.php"/>
         <const name="TESTS_GLOBAL_CONFIG_DIR" value="../../../app/etc"/>
         <const name="TESTS_CLEANUP" value="enabled"/>

--- a/magento-quick-integration-tests/docker-files/phpunit.xml
+++ b/magento-quick-integration-tests/docker-files/phpunit.xml
@@ -28,6 +28,7 @@
         <ini name="date.timezone" value="America/Los_Angeles"/>
         <ini name="xdebug.max_nesting_level" value="200"/>
         <const name="TESTS_INSTALL_CONFIG_FILE" value="etc/install-config-mysql.php"/>
+        <const name="TESTS_POST_INSTALL_SETUP_COMMAND_CONFIG_FILE" value="etc/post-install-setup-command-config.php"/>
         <const name="TESTS_GLOBAL_CONFIG_FILE" value="etc/config-global.php"/>
         <const name="TESTS_GLOBAL_CONFIG_DIR" value="../../../app/etc"/>
         <const name="TESTS_CLEANUP" value="enabled"/>


### PR DESCRIPTION
Magento 2.4.3 added a new config option `TESTS_POST_INSTALL_SETUP_COMMAND_CONFIG_FILE` for integration tests. Not having it leads to an error during the test execution, see e.g. https://github.com/firegento/firegento-magesetup2/pull/200/checks?check_run_id=3372015558. I did not test it, but I think this new config option should just be ignored by older versions, so this change should be backwards-compatible.