### PR TITLE
Support modules with src directory

### DIFF
--- a/magento-integration-tests/docker-files/phpunit.xml
+++ b/magento-integration-tests/docker-files/phpunit.xml
@@ -11,6 +11,9 @@
             <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/Test/Integration</directory>
             <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/tests/Integration</directory>
             <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/tests/integration</directory>
+            <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/src/Test/Integration</directory>
+            <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/src/tests/Integration</directory>
+            <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/src/tests/integration</directory>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
It is a common practice to move all source code into a `src` directory. Hence, we should also read integration test files from there.