### PR TITLE
feat: allow configuration of composer version in integration tests

### DIFF
--- a/magento-integration-tests/7.4/action.yml
+++ b/magento-integration-tests/7.4/action.yml
@@ -30,6 +30,10 @@ inputs:
   magento_post_install_script:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
+  composer_version:
+    description: 'The composer version to use. Can be either 1 or 2.'
+    required: false
+    default: '1'
 runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:7.4-latest'

--- a/magento-integration-tests/Dockerfile:7.0
+++ b/magento-integration-tests/Dockerfile:7.0
@@ -1,6 +1,6 @@
 FROM php:7.0-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \

--- a/magento-integration-tests/Dockerfile:7.1
+++ b/magento-integration-tests/Dockerfile:7.1
@@ -1,6 +1,6 @@
 FROM php:7.1-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \

--- a/magento-integration-tests/Dockerfile:7.2
+++ b/magento-integration-tests/Dockerfile:7.2
@@ -1,6 +1,6 @@
 FROM php:7.2-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \

--- a/magento-integration-tests/Dockerfile:7.3
+++ b/magento-integration-tests/Dockerfile:7.3
@@ -1,6 +1,6 @@
 FROM php:7.3-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \

--- a/magento-integration-tests/Dockerfile:7.4
+++ b/magento-integration-tests/Dockerfile:7.4
@@ -1,6 +1,6 @@
 FROM php:7.4-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer2
 
 RUN apt-get update && apt-get -y install --no-install-recommends \

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -9,6 +9,11 @@ test -z "${COMPOSER_NAME}" && COMPOSER_NAME=$INPUT_COMPOSER_NAME
 test -z "${MAGENTO_VERSION}" && MAGENTO_VERSION=$INPUT_MAGENTO_VERSION
 test -z "${ELASTICSEARCH}" && ELASTICSEARCH=$INPUT_ELASTICSEARCH
 test -z "${PHPUNIT_FILE}" && PHPUNIT_FILE=$INPUT_PHPUNIT_FILE
+test -z "${COMPOSER_VERSION}" && COMPOSER_VERSION=$INPUT_COMPOSER_VERSION
+
+if [ -z "$COMPOSER_VERSION" ] ; then
+    COMPOSER_VERSION=1
+fi
 
 if [[ "$MAGENTO_VERSION" == "2.4."* ]]; then
     ELASTICSEARCH=1
@@ -21,6 +26,9 @@ test -z "${MAGENTO_VERSION}" && (echo "'ce_version' is not set in your GitHub Ac
 MAGENTO_ROOT=/tmp/m2
 PROJECT_PATH=$GITHUB_WORKSPACE
 test -z "${REPOSITORY_URL}" && REPOSITORY_URL="https://repo-magento-mirror.fooman.co.nz/"
+
+echo "Using composer ${COMPOSER_VERSION}"
+ln -s /usr/local/bin/composer$COMPOSER_VERSION /usr/local/bin/composer
 
 echo "Pre Project Script [pre_project_script]: $INPUT_PRE_PROJECT_SCRIPT"
 if [[ ! -z "$INPUT_PRE_PROJECT_SCRIPT" && -f "${GITHUB_WORKSPACE}/$INPUT_PRE_PROJECT_SCRIPT" ]] ; then


### PR DESCRIPTION
This PR provides a way to configure the composer version used in integration tests.

Composer 2 was only installed in the Dockerfile for 7.4 so I added the config option only there. IIRC composer 2 requires 7.4? (or at least 7.3?)