### PR TITLE
fix coding standard image build

### DIFF
--- a/.github/workflows/coding-standard-images.yml
+++ b/.github/workflows/coding-standard-images.yml
@@ -17,7 +17,7 @@ jobs:
           - "7.3"
           - "7.4"
         actions-with-docker-image:
-          - "magento-coding-standard-tests"
+          - "magento-coding-standard"
     env:
       DOCKER_USERNAME: "extdn"
 


### PR DESCRIPTION
Since the addition of php 7.4 to the magento coding standard action the [build of the images]( https://github.com/extdn/github-actions-m2/actions/runs/1330938064) fails with the error:
```
unable to prepare context: path "magento-coding-standard-tests/." not found
```

this should fix #43 