### PR TITLE
static code analysis with the PHPCompatibility Coding Standard

### DIFF
--- a/php-compatibility/7.3/action.yml
+++ b/php-compatibility/7.3/action.yml
@@ -1,0 +1,13 @@
+name: 'PHPCompatibility'
+author: 'ExtDN'
+description: 'performs php static code analysis with the PHPCompatibility Coding Standard'
+inputs:
+  phpcs_standard:
+    description: 'PHPCompatibility standard.'
+    required: false
+runs:
+  using: 'docker'
+  image: 'docker://extdn/php-compatibility-action:7.3-latest'
+branding:
+  icon: 'code'  
+  color: 'green'

--- a/php-compatibility/7.4/action.yml
+++ b/php-compatibility/7.4/action.yml
@@ -1,0 +1,13 @@
+name: 'PHPCompatibility'
+author: 'ExtDN'
+description: 'performs php static code analysis with the PHPCompatibility Coding Standard'
+inputs:
+  phpcs_standard:
+    description: 'PHPCompatibility standard.'
+    required: false
+runs:
+  using: 'docker'
+  image: 'docker://extdn/php-compatibility-action:7.4-latest'
+branding:
+  icon: 'code'  
+  color: 'green'

--- a/php-compatibility/Dockerfile:7.3
+++ b/php-compatibility/Dockerfile:7.3
@@ -1,0 +1,11 @@
+FROM php:7.3-cli-alpine3.9
+
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+
+RUN /usr/local/bin/composer global require phpcompatibility/php-compatibility:*
+RUN ~/.composer/vendor/bin/phpcs --config-set installed_paths ../../phpcompatibility/php-compatibility
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+
+ADD problem-matcher.json /problem-matcher.json
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/php-compatibility/Dockerfile:7.4
+++ b/php-compatibility/Dockerfile:7.4
@@ -1,0 +1,11 @@
+FROM php:7.4-cli-alpine
+
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+
+RUN /usr/local/bin/composer global require phpcompatibility/php-compatibility:*
+RUN ~/.composer/vendor/bin/phpcs --config-set installed_paths ../../phpcompatibility/php-compatibility
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+
+ADD problem-matcher.json /problem-matcher.json
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/php-compatibility/action.yml
+++ b/php-compatibility/action.yml
@@ -3,7 +3,7 @@ author: 'ExtDN'
 description: 'performs php static code analysis with the PHPCompatibility Standard'
 inputs:
   phpcs_standard:
-    description: 'Path to your own PHPCS file or a specific standard. Leave empty to use "PHPCompatibility".'
+    description: 'PHPCompatibility standard'
     required: false
 runs:
   using: 'docker'

--- a/php-compatibility/action.yml
+++ b/php-compatibility/action.yml
@@ -1,0 +1,13 @@
+name: 'PHPCompatibility'
+author: 'ExtDN'
+description: 'performs php static code analysis with the PHPCompatibility Standard'
+inputs:
+  phpcs_standard:
+    description: 'Path to your own PHPCS file or a specific standard. Leave empty to use "PHPCompatibility".'
+    required: false
+runs:
+  using: 'docker'
+  image: 'docker://extdn/php-compatibility-action:latest'
+branding:
+  icon: 'code'  
+  color: 'green'

--- a/php-compatibility/entrypoint.sh
+++ b/php-compatibility/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -l
+
+# Copy the matcher to a shared volume with the host; otherwise "add-matcher"
+# can't find it.
+cp /problem-matcher.json ${HOME}/
+echo "::add-matcher::${HOME}/problem-matcher.json"
+
+cd $GITHUB_WORKSPACE
+test -z "${INPUT_RUNTIME}" && INPUT_RUNTIME=7.3-7.4
+sh -c "/root/.composer/vendor/bin/phpcs --report=checkstyle --standard=PHPCompatibility --runtime-set testVersion $INPUT_RUNTIME $GITHUB_WORKSPACE -s $*"

--- a/php-compatibility/problem-matcher.json
+++ b/php-compatibility/problem-matcher.json
@@ -1,0 +1,23 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "phpcs",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^<file name=\"(?:\\/github\\/workspace\\/)?(.*)\">$",
+          "file": 1
+        },
+        {
+          "regexp": "<error line=\"(\\d*)\" column=\"(\\d*)\" severity=\"(error|warning)\" message=\"(.*)\" source=\"(.*)(\"\\/>+)$",
+          "line": 1,
+          "column": 2,
+          "severity": 3,
+          "message": 4,
+          "code": 5,
+          "loop": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Apologies I'm on a windows machine at the moment so can't fully test this e.g can't even clone repo due to file naming convention. And can only do so much using WSL.

So basically I've taken a wild stab in the dark on how I think this should work. Could need further work. Also what that means is that I can't do a great deal of editing if changes are required to the PR.

Personally for me I think it would be really handy to have a static code analysis with the specifically the PHPCompatibility coding standard but allowing adjustment of test version.