### PR TITLE
Add pcntl extension, as suggested by Magento

### DIFF
--- a/magento-integration-tests/Dockerfile:7.0
+++ b/magento-integration-tests/Dockerfile:7.0
@@ -31,6 +31,7 @@ RUN docker-php-ext-install bcmath
 RUN docker-php-ext-install mcrypt
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
+RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
 RUN /usr/local/bin/composer1 global require hirak/prestissimo
 
@@ -41,4 +42,3 @@ COPY docker-files /docker-files
 RUN echo 'memory_limit = -1' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
-

--- a/magento-integration-tests/Dockerfile:7.1
+++ b/magento-integration-tests/Dockerfile:7.1
@@ -31,6 +31,7 @@ RUN docker-php-ext-install bcmath
 RUN docker-php-ext-install mcrypt
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
+RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
 RUN /usr/local/bin/composer1 global require hirak/prestissimo
 
@@ -41,4 +42,3 @@ COPY docker-files /docker-files
 RUN echo 'memory_limit = -1' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
-

--- a/magento-integration-tests/Dockerfile:7.2
+++ b/magento-integration-tests/Dockerfile:7.2
@@ -31,6 +31,7 @@ RUN docker-php-ext-install bcmath
 RUN docker-php-ext-install sodium
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
+RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
 RUN /usr/local/bin/composer1 global require hirak/prestissimo
 
@@ -41,4 +42,3 @@ COPY docker-files /docker-files
 RUN echo 'memory_limit = -1' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
-

--- a/magento-integration-tests/Dockerfile:7.3
+++ b/magento-integration-tests/Dockerfile:7.3
@@ -31,6 +31,7 @@ RUN docker-php-ext-install bcmath
 RUN docker-php-ext-install sodium
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
+RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
 RUN /usr/local/bin/composer1 global require hirak/prestissimo
 
@@ -41,4 +42,3 @@ COPY docker-files /docker-files
 RUN echo 'memory_limit = -1' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
-

--- a/magento-integration-tests/Dockerfile:7.4
+++ b/magento-integration-tests/Dockerfile:7.4
@@ -32,6 +32,7 @@ RUN docker-php-ext-install bcmath
 RUN docker-php-ext-install sodium
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
+RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
 
 COPY entrypoint.sh /entrypoint.sh
@@ -41,4 +42,3 @@ COPY docker-files /docker-files
 RUN echo 'memory_limit = -1' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
-

--- a/magento-integration-tests/Dockerfile:8.1
+++ b/magento-integration-tests/Dockerfile:8.1
@@ -31,6 +31,7 @@ RUN docker-php-ext-install bcmath
 RUN docker-php-ext-install sodium
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
+RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
 
 COPY entrypoint.sh /entrypoint.sh
@@ -40,4 +41,3 @@ COPY docker-files /docker-files
 RUN echo 'memory_limit = -1' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
-


### PR DESCRIPTION
The PHP extension 'pcntl' is [recommended by Magento](https://github.com/magento/magento2/blob/83f3d01e1a4fe6ac7b79c9996403a32643c3b399/composer.json#L101-L103), but is missing from these images. A module I'm working on [uses this extension](https://github.com/Ethan3600/magento2-CronjobManager/blob/1057e3406bbf927a23341afb6bfef176a878a87f/composer.json#L9-L11) in [its tests](https://github.com/Ethan3600/magento2-CronjobManager/blob/1057e3406bbf927a23341afb6bfef176a878a87f/Test/Integration/ProcessKillRequestsTest.php#L139).

This pull request adds the 'pcntl' extension to all integration test images.