### PR TITLE
Integration tests fail for magento 2.4.6 as it uses Opensearch by default 

### DIFF
--- a/magento-integration-tests/docker-files/install-config-mysql-with-es.php
+++ b/magento-integration-tests/docker-files/install-config-mysql-with-es.php
@@ -11,6 +11,7 @@ return [
     'admin-email' => \Magento\TestFramework\Bootstrap::ADMIN_EMAIL,
     'admin-firstname' => \Magento\TestFramework\Bootstrap::ADMIN_FIRSTNAME,
     'admin-lastname' => \Magento\TestFramework\Bootstrap::ADMIN_LASTNAME,
+    'search-engine' => 'elasticsearch7',
     'elasticsearch-host' => 'es',
     'elasticsearch-port' => '9200',
 ];

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -105,9 +105,10 @@ SETUP_ARGS="--base-url=http://magento2.test/ \
 --currency=USD --timezone=Europe/Amsterdam \
 --sales-order-increment-prefix=ORD_ --session-save=db \
 --use-rewrites=1"
+--search-engine=elasticsearch7
 
 if [[ "$ELASTICSEARCH" == "1" ]]; then
-    SETUP_ARGS="$SETUP_ARGS --search-engine=elasticsearch7 --elasticsearch-host=es --elasticsearch-port=9200 --elasticsearch-enable-auth=0 --elasticsearch-timeout=60"
+    SETUP_ARGS="$SETUP_ARGS --elasticsearch-host=es --elasticsearch-port=9200 --elasticsearch-enable-auth=0 --elasticsearch-timeout=60"
 fi
 
 echo "Run Magento setup: $SETUP_ARGS"

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -107,7 +107,7 @@ SETUP_ARGS="--base-url=http://magento2.test/ \
 --use-rewrites=1"
 
 if [[ "$ELASTICSEARCH" == "1" ]]; then
-    SETUP_ARGS="$SETUP_ARGS --elasticsearch-host=es --elasticsearch-port=9200 --elasticsearch-enable-auth=0 --elasticsearch-timeout=60"
+    SETUP_ARGS="$SETUP_ARGS --search-engine=elasticsearch7 --elasticsearch-host=es --elasticsearch-port=9200 --elasticsearch-enable-auth=0 --elasticsearch-timeout=60"
 fi
 
 echo "Run Magento setup: $SETUP_ARGS"

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -104,8 +104,9 @@ SETUP_ARGS="--base-url=http://magento2.test/ \
 --backend-frontname=admin --language=en_US \
 --currency=USD --timezone=Europe/Amsterdam \
 --sales-order-increment-prefix=ORD_ --session-save=db \
---use-rewrites=1"
---search-engine=elasticsearch7
+--use-rewrites=1
+--search-engine=elasticsearch7"
+
 
 if [[ "$ELASTICSEARCH" == "1" ]]; then
     SETUP_ARGS="$SETUP_ARGS --elasticsearch-host=es --elasticsearch-port=9200 --elasticsearch-enable-auth=0 --elasticsearch-timeout=60"


### PR DESCRIPTION
By default, Magento 2.4.6 uses OpenSearch, leading to all integration tests' failure. 
To resolve this issue, it is recommended to include a tag during installation that sets the search engine to ES7. If you want to replicate the problem, simply create an integration test for Magento 2.4.6 using PHP 8.1 and commit it to GitHub. This will show that the integration test has indeed failed.

![image](https://user-images.githubusercontent.com/16300182/235952382-405fdd66-d32c-488d-b571-ae4224415b8f.png)


