### PR TITLE
Quick Integration tests fail for magento 2.4.6 as it uses Opensearch by default

### DIFF
--- a/magento-quick-integration-tests/entrypoint.sh
+++ b/magento-quick-integration-tests/entrypoint.sh
@@ -54,7 +54,8 @@ php -d memory_limit=2G bin/magento setup:install --base-url=http://magento2.test
 --backend-frontname=admin --language=en_US \
 --currency=USD --timezone=Europe/Amsterdam --cleanup-database \
 --sales-order-increment-prefix="ORD$" --session-save=db \
---use-rewrites=1
+--use-rewrites=1 \
+--search-engine=elasticsearch7
 
 echo "Enable the module"
 cd $MAGENTO_ROOT

--- a/magento-quick-integration-tests/entrypoint.sh
+++ b/magento-quick-integration-tests/entrypoint.sh
@@ -45,20 +45,29 @@ echo "Run installation"
 COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist --no-interaction --no-progress 
 
 echo "Run Magento setup"
-
-SETUP_ARGS="--db-host=mysql --db-name=magento2 \
+SETUP_ARGS="--base-url=http://magento2.test/ \
+--db-host=mysql --db-name=magento2 \
 --db-user=root --db-password=root \
 --admin-firstname=John --admin-lastname=Doe \
 --admin-email=johndoe@example.com \
 --admin-user=johndoe --admin-password=johndoe!1234 \
 --backend-frontname=admin --language=en_US \
---currency=USD --timezone=Europe/Amsterdam --cleanup-database \
---sales-order-increment-prefix="ORD$" --session-save=db \
+--currency=USD --timezone=Europe/Amsterdam \
+--sales-order-increment-prefix=ORD_ --session-save=db \
 --use-rewrites=1"
+
+# only add the --search-engine param if it is supported
 if bin/magento setup:install --help | grep -q '\-\-search\-engine='; then
     SETUP_ARGS="$SETUP_ARGS --search-engine=elasticsearch7"
 fi
-php -d memory_limit=2G bin/magento setup:install --base-url=http://magento2.test/ \$SETUP_ARGS
+
+if [[ "$ELASTICSEARCH" == "1" ]]; then
+    SETUP_ARGS="$SETUP_ARGS --elasticsearch-host=es --elasticsearch-port=9200 --elasticsearch-enable-auth=0 --elasticsearch-timeout=60"
+fi
+
+echo "Run Magento setup: $SETUP_ARGS"
+php bin/magento setup:install $SETUP_ARGS
+
 echo "Enable the module"
 cd $MAGENTO_ROOT
 bin/magento module:enable ${MODULE_NAME}

--- a/magento-quick-integration-tests/entrypoint.sh
+++ b/magento-quick-integration-tests/entrypoint.sh
@@ -45,8 +45,8 @@ echo "Run installation"
 COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist --no-interaction --no-progress 
 
 echo "Run Magento setup"
-php -d memory_limit=2G bin/magento setup:install --base-url=http://magento2.test/ \
---db-host=mysql --db-name=magento2 \
+
+SETUP_ARGS="--db-host=mysql --db-name=magento2 \
 --db-user=root --db-password=root \
 --admin-firstname=John --admin-lastname=Doe \
 --admin-email=johndoe@example.com \
@@ -54,9 +54,11 @@ php -d memory_limit=2G bin/magento setup:install --base-url=http://magento2.test
 --backend-frontname=admin --language=en_US \
 --currency=USD --timezone=Europe/Amsterdam --cleanup-database \
 --sales-order-increment-prefix="ORD$" --session-save=db \
---use-rewrites=1 \
---search-engine=elasticsearch7
-
+--use-rewrites=1"
+if bin/magento setup:install --help | grep -q '\-\-search\-engine='; then
+    SETUP_ARGS="$SETUP_ARGS --search-engine=elasticsearch7"
+fi
+php -d memory_limit=2G bin/magento setup:install --base-url=http://magento2.test/ \$SETUP_ARGS
 echo "Enable the module"
 cd $MAGENTO_ROOT
 bin/magento module:enable ${MODULE_NAME}


### PR DESCRIPTION
To avoid quick integration test failures in Magento 2.4.6, it's advisable to set the search engine to ES7 by including a tag during installation. OpenSearch, the default search engine in Magento 2.4.6, can cause this issue. If you wish to replicate the problem, create an integration test for Magento 2.4.6 using PHP 8.1 and commit it to GitHub. This will verify the failed quick integration test.