### PR TITLE
Do not use symlinks with PHPStan

### DIFF
--- a/magento-phpstan/entrypoint.sh
+++ b/magento-phpstan/entrypoint.sh
@@ -39,7 +39,7 @@ if [ -n "$INPUT_MAGENTO_PRE_INSTALL_SCRIPT" ] && [ -f "${GITHUB_WORKSPACE}"/"$IN
 fi;
 
 echo "Run installation"
-composer require $COMPOSER_NAME:@dev --no-interaction --dev
+COMPOSER_MIRROR_PATH_REPOS=1 composer require $COMPOSER_NAME:@dev --no-interaction --dev
 
 CONFIGURATION_FILE=$MAGENTO_ROOT/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon
 test -f $GITHUB_WORKSPACE/${MODULE_SOURCE}/phpstan.neon && CONFIGURATION_FILE=$GITHUB_WORKSPACE/${MODULE_SOURCE}/phpstan.neon


### PR DESCRIPTION
PHPStan has - only in certain cases, but still - issues with symlinks. See e.g.:

https://github.com/phpstan/phpstan/issues/7241
https://github.com/phpstan/phpstan/issues/6585

This PR suggests to use [`COMPOSER_MIRROR_PATH_REPOS`](https://getcomposer.org/doc/03-cli.md#composer-mirror-path-repos) for the PHPStan action, so that the package is actually copied and not symlinked from the local path repository to fix such issues.