### PR TITLE
Only build images on master push

### DIFF
--- a/.github/workflows/coding-standard-images.yml
+++ b/.github/workflows/coding-standard-images.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: "0 6 * * 0" # 6 AM Weekly
   push:
+    branches:
+      - master
     paths:
       - 'magento-coding-standard/**'
 

--- a/.github/workflows/integration-test-images.yml
+++ b/.github/workflows/integration-test-images.yml
@@ -3,6 +3,8 @@ name: Build Integration Images
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
     paths:
       - 'magento-integration-tests/**'
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -3,6 +3,8 @@ name: Build PHP compatibility Images
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
     paths:
       - 'php-compatibility/**'
 

--- a/.github/workflows/phpstan-images.yml
+++ b/.github/workflows/phpstan-images.yml
@@ -3,6 +3,8 @@ name: Build PHPStan Images
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
     paths:
       - 'magento-phpstan/**'
 

--- a/.github/workflows/unit-test-images.yml
+++ b/.github/workflows/unit-test-images.yml
@@ -3,6 +3,8 @@ name: Build Unit Testing Images
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
     paths:
       - 'magento-unit-tests/**'
 


### PR DESCRIPTION
We should only update Docker Images when we actually push to `master`. Otherwise, any PR changes our Docker images, which is quite bad :see_no_evil: 