### PR TITLE
Make GitHub Actions inputs consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This repository's aim is to provide a set of open sourced GitHub actions to writ
 
 # Available Actions
 ## Magento Coding Standard
-Provides an action that can be used in your GitHub workflow to execute the latest [Magento Coding Standard](https://github.com/magento/magento-coding-standard). 
+Provides an action that can be used in your GitHub workflow to execute the latest [Magento Coding Standard](https://github.com/magento/magento-coding-standard).
 
 #### Screenshot
 ![Screenshot Coding Style Action](magento-coding-standard/screenshot.png?raw=true")
 
 #### How to use it
-In your GitHub repository add the below as 
+In your GitHub repository add the below as
 `.github/workflows/coding-standard.yml`
 
 ```
@@ -37,7 +37,7 @@ Run your Magento 2 integration tests via this Github Action. All you need is to 
 #### Screenshot
 ![Screenshot Mess Detector Action](magento-integration-tests/screenshot.png?raw=true")
 #### How to use it
-In your GitHub repository add the below as 
+In your GitHub repository add the below as
 `.github/workflows/integration.yml`
 
 ```
@@ -76,7 +76,7 @@ jobs:
         with:
           module_name: Foo_Bar
           composer_name: foo/magento2-foobar
-          ce_version: '2.4.0'
+          magento_version: '2.4.0'
 ```
 
 The following images are provided for use
@@ -92,7 +92,7 @@ The following inputs are required:
 |---|---|
 | module_name   | Your Magento module name. Example: Foo_Bar   |
 | composer_name   | Your composer name. Example: foo/magento2-bar   |
-| ce_version  | Magento 2 Open Source version number. Example: 2.4.0  |
+| magento_version | Magento 2 Open Source version number. Example: 2.4.0  |
 
 
 
@@ -105,25 +105,25 @@ The default [phpunit.xml](https://github.com/extdn/github-actions-m2/blob/master
 
 If this phpunit file does not work for you can provide a relative path to your own PHPUnit file via phpunit_file
 
-``` 
+```
       - name: M2 Integration Tests with Magento 2 (Php7.4)
         uses: extdn/github-actions-m2/magento-integration-tests/7.4@master
         with:
           module_name: Foo_Bar
           composer_name: foo/magento2-foobar
-          ce_version: '2.4.0'
+          magento_version: '2.4.0'
           phpunit_file: './path/to/phpunit.xml'
 ```
 
 Sometimes it may be needed to run additional commands before tests can run. For example to add or remove additional dependencies. Use the input magento_pre_install_script to provide a relative path to this script. Example
 
-``` 
+```
       - name: M2 Integration Tests with Magento 2 (Php7.4)
         uses: extdn/github-actions-m2/magento-integration-tests/7.4@master
         with:
           module_name: Foo_Bar
           composer_name: foo/magento2-foobar
-          ce_version: '2.4.0'
+          magento_version: '2.4.0'
           magento_pre_install_script: './.github/integration-test-setup.sh'
 ```
 
@@ -135,7 +135,7 @@ Provides an action that can be used in your GitHub workflow to execute the PHP M
 #### Screenshot
 ![Screenshot Mess Detector Action](magento-mess-detector/screenshot.png?raw=true")
 #### How to use it
-In your GitHub repository add the below as 
+In your GitHub repository add the below as
 `.github/workflows/mess-detector.yml`
 
 ```
@@ -161,7 +161,7 @@ jobs:
 Provides an action that can be used in your GitHub workflow to execute the PHP Copy Paste Detector rules included in Magento 2 ([link](https://github.com/magento/magento2/blob/2.3.4/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/CopyPasteDetector.php)).
 
 #### How to use it
-In your GitHub repository add the below as 
+In your GitHub repository add the below as
 `.github/workflows/copy-paste-detector.yml`
 
 ```
@@ -190,7 +190,7 @@ Provides an action that can be used in your GitHub workflow to execute the PHPSt
 ![Screenshot PHPStan Action](magento-phpstan/screenshot.png?raw=true")
 
 #### How to use it
-In your GitHub repository add the below as 
+In your GitHub repository add the below as
 `.github/workflows/phpstan.yml`
 
 ```
@@ -216,7 +216,7 @@ jobs:
 Provides an action that can be used in your GitHub workflow to execute blackfire.io profiling before and after installing extension code.
 
 #### How to use it
-In your GitHub repository add the below as 
+In your GitHub repository add the below as
 `.github/workflows/performance.yml`
 
 ```
@@ -350,4 +350,3 @@ jobs:
       MAGENTO_MARKETPLACE_USERNAME: foo
       MAGENTO_MARKETPLACE_PASSWORD: bar
 ```
-

--- a/install-m2-from-mirror/action.yml
+++ b/install-m2-from-mirror/action.yml
@@ -3,9 +3,15 @@ author: 'ExtDN'
 description: 'performs installation of Magento 2 open source version'
 inputs:
   ce-version:
+    description: 'Deprecated. Please use "magento_version" instead.'
+  magento_version:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.3.3'
+  project_name:
+    description: 'Magento 2 project name'
+    required: true
+    default: 'magento/project-community-edition'
   db-host:
     description: 'Database Host'
     default: 'mysql'

--- a/install-m2-from-mirror/dist/index.js
+++ b/install-m2-from-mirror/dist/index.js
@@ -1023,17 +1023,18 @@ const core = __webpack_require__(470);
 const exec = __webpack_require__(986);
 
 async function run() {
-try { 
-    const ceversion = core.getInput('ce-version');
+try {
+    const magento_version = core.getInput('magento_version') || core.getInput('ce-version');
+    const project_name = core.getInput('project_name');
     const options = {};
     await exec.exec(`sudo composer self-update 1.10.16`);
-    await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-plugins magento/project-community-edition m2-folder ${ceversion}`);
+    await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-plugins ${project_name} m2-folder ${magento_version}`);
     options.cwd = './m2-folder';
     await exec.exec('composer', ['config', '--unset', 'repo.0'], options);
     await exec.exec('composer', ['config', 'repositories.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);
     await exec.exec('composer', ['install', '--prefer-dist'], options);
 
-    await exec.exec('bin/magento', 
+    await exec.exec('bin/magento',
         [
           'setup:install',
           '--db-host=' + core.getInput('db-host') +':'+ core.getInput('db-port'),
@@ -1051,7 +1052,7 @@ try {
           '--timezone=America/New_York',
           '--use-rewrites=1'
         ], options);
-    } 
+    }
     catch (error) {
         core.setFailed(error.message);
     }

--- a/install-m2-from-mirror/index.js
+++ b/install-m2-from-mirror/index.js
@@ -2,17 +2,18 @@ const core = require('@actions/core');
 const exec = require('@actions/exec');
 
 async function run() {
-try { 
-    const ceversion = core.getInput('ce-version');
+try {
+    const magento_version = core.getInput('magento_version') || core.getInput('ce-version');
+    const project_name = core.getInput('project_name');
     const options = {};
     await exec.exec(`sudo composer self-update 1.10.16`);
-    await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-plugins magento/project-community-edition m2-folder ${ceversion}`);
+    await exec.exec(`composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-install --no-progress --no-plugins ${project_name} m2-folder ${magento_version}`);
     options.cwd = './m2-folder';
     await exec.exec('composer', ['config', '--unset', 'repo.0'], options);
     await exec.exec('composer', ['config', 'repositories.foomanmirror', 'composer', 'https://repo-magento-mirror.fooman.co.nz/'], options);
     await exec.exec('composer', ['install', '--prefer-dist'], options);
 
-    await exec.exec('bin/magento', 
+    await exec.exec('bin/magento',
         [
           'setup:install',
           '--db-host=' + core.getInput('db-host') +':'+ core.getInput('db-port'),
@@ -30,7 +31,7 @@ try {
           '--timezone=America/New_York',
           '--use-rewrites=1'
         ], options);
-    } 
+    }
     catch (error) {
         core.setFailed(error.message);
     }

--- a/magento-integration-tests/7.0/action.yml
+++ b/magento-integration-tests/7.0/action.yml
@@ -9,13 +9,15 @@ inputs:
     description: 'Your composer name. Example: foo/magento2-bar'
     required: true
   ce_version:
+    description: 'Deprecated. Please use "magento_version" instead.'
+  magento_version:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.3.5-p2'
   project_name:
     description: 'Magento 2 project name'
     required: true
-    default: 'magento/project-community-edition'    
+    default: 'magento/project-community-edition'
   module_source:
     description: 'Relative path to your module source within your repository. Empty by default.'
     required: false
@@ -38,13 +40,8 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:7.0-latest'
   env:
-    MODULE_NAME: ${{ inputs.module_name }}
-    COMPOSER_NAME: ${{ inputs.composer_name }}
-    MAGENTO_VERSION: ${{ inputs.ce_version }}
-    PROJECT_NAME: ${{ inputs.project_name }}
     COMPOSER_MEMORY_LIMIT: -1
 
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'green'
-

--- a/magento-integration-tests/7.1/action.yml
+++ b/magento-integration-tests/7.1/action.yml
@@ -9,13 +9,15 @@ inputs:
     description: 'Your composer name. Example: foo/magento2-bar'
     required: true
   ce_version:
+    description: 'Deprecated. Please use "magento_version" instead.'
+  magento_version:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.3.5-p2'
   project_name:
     description: 'Magento 2 project name'
     required: true
-    default: 'magento/project-community-edition'    
+    default: 'magento/project-community-edition'
   module_source:
     description: 'Relative path to your module source within your repository. Empty by default.'
     required: false
@@ -38,13 +40,8 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:7.1-latest'
   env:
-    MODULE_NAME: ${{ inputs.module_name }}
-    COMPOSER_NAME: ${{ inputs.composer_name }}
-    MAGENTO_VERSION: ${{ inputs.ce_version }}
-    PROJECT_NAME: ${{ inputs.project_name }}
     COMPOSER_MEMORY_LIMIT: -1
 
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'green'
-

--- a/magento-integration-tests/7.2/action.yml
+++ b/magento-integration-tests/7.2/action.yml
@@ -9,13 +9,15 @@ inputs:
     description: 'Your composer name. Example: foo/magento2-bar'
     required: true
   ce_version:
+    description: 'Deprecated. Please use "magento_version" instead.'
+  magento_version:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.3.5-p2'
   project_name:
     description: 'Magento 2 project name'
     required: true
-    default: 'magento/project-community-edition'    
+    default: 'magento/project-community-edition'
   module_source:
     description: 'Relative path to your module source within your repository. Empty by default.'
     required: false
@@ -38,13 +40,8 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:7.2-latest'
   env:
-    MODULE_NAME: ${{ inputs.module_name }}
-    COMPOSER_NAME: ${{ inputs.composer_name }}
-    MAGENTO_VERSION: ${{ inputs.ce_version }}
-    PROJECT_NAME: ${{ inputs.project_name }}
     COMPOSER_MEMORY_LIMIT: -1
 
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'green'
-

--- a/magento-integration-tests/7.3/action.yml
+++ b/magento-integration-tests/7.3/action.yml
@@ -9,13 +9,15 @@ inputs:
     description: 'Your composer name. Example: foo/magento2-bar'
     required: true
   ce_version:
+    description: 'Deprecated. Please use "magento_version" instead.'
+  magento_version:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.4.0'
   project_name:
     description: 'Magento 2 project name'
     required: true
-    default: 'magento/project-community-edition'    
+    default: 'magento/project-community-edition'
   module_source:
     description: 'Relative path to your module source within your repository. Empty by default.'
     required: false
@@ -38,13 +40,8 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:7.3-latest'
   env:
-    MODULE_NAME: ${{ inputs.module_name }}
-    COMPOSER_NAME: ${{ inputs.composer_name }}
-    MAGENTO_VERSION: ${{ inputs.ce_version }}
-    PROJECT_NAME: ${{ inputs.project_name }}
     COMPOSER_MEMORY_LIMIT: -1
 
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'green'
-

--- a/magento-integration-tests/7.4/action.yml
+++ b/magento-integration-tests/7.4/action.yml
@@ -9,6 +9,8 @@ inputs:
     description: 'Your composer name. Example: foo/magento2-bar'
     required: true
   ce_version:
+    description: 'Deprecated. Please use "magento_version" instead.'
+  magento_version:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.4.3'
@@ -42,13 +44,8 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:7.4-latest'
   env:
-    MODULE_NAME: ${{ inputs.module_name }}
-    COMPOSER_NAME: ${{ inputs.composer_name }}
-    MAGENTO_VERSION: ${{ inputs.ce_version }}
-    PROJECT_NAME: ${{ inputs.project_name }}
     COMPOSER_MEMORY_LIMIT: -1
 
 branding:
   icon: 'code'
   color: 'green'
-

--- a/magento-integration-tests/8.1/action.yml
+++ b/magento-integration-tests/8.1/action.yml
@@ -9,6 +9,8 @@ inputs:
     description: 'Your composer name. Example: foo/magento2-bar'
     required: true
   ce_version:
+    description: 'Deprecated. Please use "magento_version" instead.'
+  magento_version:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.4.4'
@@ -42,13 +44,8 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:8.1-latest'
   env:
-    MODULE_NAME: ${{ inputs.module_name }}
-    COMPOSER_NAME: ${{ inputs.composer_name }}
-    MAGENTO_VERSION: ${{ inputs.ce_version }}
-    PROJECT_NAME: ${{ inputs.project_name }}
     COMPOSER_MEMORY_LIMIT: -1
 
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'green'
-

--- a/magento-integration-tests/8.2/action.yml
+++ b/magento-integration-tests/8.2/action.yml
@@ -9,6 +9,8 @@ inputs:
     description: 'Your composer name. Example: foo/magento2-bar'
     required: true
   ce_version:
+    description: 'Deprecated. Please use "magento_version" instead.'
+  magento_version:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.4.6-p3'
@@ -42,10 +44,6 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:8.2-latest'
   env:
-    MODULE_NAME: ${{ inputs.module_name }}
-    COMPOSER_NAME: ${{ inputs.composer_name }}
-    MAGENTO_VERSION: ${{ inputs.ce_version }}
-    PROJECT_NAME: ${{ inputs.project_name }}
     COMPOSER_MEMORY_LIMIT: -1
 
 branding:

--- a/magento-integration-tests/README.md
+++ b/magento-integration-tests/README.md
@@ -32,7 +32,7 @@ jobs:
         with:
           module_name: Foo_Bar
           composer_name: foo/magento2-foobar
-          ce_version: '2.4.0'
+          magento_version: '2.4.0'
 ```
 
 Make sure to modify the following values:
@@ -49,4 +49,3 @@ a custom XML file using `PHPUNIT_FILE`. And there is an environment variable `MA
 are run.
 
 See `entrypoint.sh` for clearification.
-

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -2,9 +2,8 @@
 
 set -e
 
-test -z "${CE_VERSION}" || MAGENTO_VERSION=$CE_VERSION
-
 test -z "${MODULE_NAME}" && MODULE_NAME=$INPUT_MODULE_NAME
+test -z "${MODULE_SOURCE}" && MODULE_SOURCE=$INPUT_MODULE_SOURCE
 test -z "${COMPOSER_NAME}" && COMPOSER_NAME=$INPUT_COMPOSER_NAME
 test -z "${MAGENTO_VERSION}" && MAGENTO_VERSION=$INPUT_MAGENTO_VERSION
 test -z "${PROJECT_NAME}" && PROJECT_NAME=$INPUT_PROJECT_NAME
@@ -12,6 +11,10 @@ test -z "${ELASTICSEARCH}" && ELASTICSEARCH=$INPUT_ELASTICSEARCH
 test -z "${PHPUNIT_FILE}" && PHPUNIT_FILE=$INPUT_PHPUNIT_FILE
 test -z "${COMPOSER_VERSION}" && COMPOSER_VERSION=$INPUT_COMPOSER_VERSION
 test -z "${REPOSITORY_URL}" && REPOSITORY_URL=$INPUT_REPOSITORY_URL
+
+# Maintain backwards-compatibility with old 'ce_version' input.
+test -z "${MAGENTO_VERSION}" && MAGENTO_VERSION=$INPUT_CE_VERSION
+test -z "${MAGENTO_VERSION}" && MAGENTO_VERSION=$CE_VERSION
 
 test -z "$MAGENTO_VERSION" && MAGENTO_VERSION="2.4.3-p1"
 test -z "$COMPOSER_VERSION" && [[ "$MAGENTO_VERSION" =~ ^2.4.* ]] && COMPOSER_VERSION=2
@@ -25,8 +28,6 @@ fi
 
 test -z "${MODULE_NAME}" && (echo "'module_name' is not set")
 test -z "${COMPOSER_NAME}" && (echo "'composer_name' is not set" && exit 1)
-test -z "${MAGENTO_VERSION}" && (echo "'ce_version' is not set" && exit 1)
-test -z "${PROJECT_NAME}" && (echo "'project_name' is not set" && exit 1)
 
 MAGENTO_ROOT=/tmp/m2
 PROJECT_PATH=$GITHUB_WORKSPACE
@@ -156,4 +157,3 @@ php -r "echo ini_get('memory_limit').PHP_EOL;"
 
 echo "Run the integration tests"
 cd $MAGENTO_ROOT/dev/tests/integration && ../../../vendor/bin/phpunit -c phpunit.xml
-

--- a/magento-performance-compare/action.yml
+++ b/magento-performance-compare/action.yml
@@ -6,12 +6,6 @@ inputs:
     description: 'The GitHub authentication token'
     required: true
     default: ${{ github.token }}
-  extension-name:
-    description: 'Module Name of Magento 2 Extension'
-    required: true
-  extension-package-name:
-    description: 'Composer package name of extension'
-    required: true
   baseline-file:
     required: true
     description: 'Path to blackfire.io json profile before'

--- a/magento-phpstan/entrypoint.sh
+++ b/magento-phpstan/entrypoint.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -e
 
+test -z "${MODULE_SOURCE}" && MODULE_SOURCE=$INPUT_MODULE_SOURCE
+test -z "${COMPOSER_NAME}" && COMPOSER_NAME=$INPUT_COMPOSER_NAME
 test -z "${COMPOSER_VERSION}" && COMPOSER_VERSION=$INPUT_COMPOSER_VERSION
+
 if [ -z "$COMPOSER_VERSION" ] ; then
    COMPOSER_VERSION=2
 fi
 
-test -z "${COMPOSER_NAME}" && COMPOSER_NAME=$INPUT_COMPOSER_NAME
 EXTENSION_BRANCH=${GITHUB_REF#refs/heads/}
 
 MAGENTO_ROOT=/m2
@@ -55,4 +57,3 @@ php $MAGENTO_ROOT/vendor/bin/phpstan analyse \
     --memory-limit=4G \
     --configuration ${CONFIGURATION_FILE} \
     ${GITHUB_WORKSPACE}/${MODULE_SOURCE}
-

--- a/magento-quick-integration-tests/README.md
+++ b/magento-quick-integration-tests/README.md
@@ -28,7 +28,7 @@ jobs:
         env:
             MODULE_NAME: Foo_Bar
             COMPOSER_NAME: foo/magento2-foobar
-            CE_VERSION: 2.3.5
+            MAGENTO_VERSION: 2.3.5
 ```
 
 Make sure to modify the following values:

--- a/magento-quick-integration-tests/action.yml
+++ b/magento-quick-integration-tests/action.yml
@@ -9,9 +9,15 @@ inputs:
     description: 'Your composer name. Example: foo/magento2-bar'
     required: true
   ce_version:
+    description: 'Deprecated. Please use "magento_version" instead.'
+  magento_version:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.3.5'
+  project_name:
+    description: 'Magento 2 project name'
+    required: true
+    default: 'magento/project-community-edition'
   module_source:
     description: 'Relative path to your module source within your repository. Empty by default.'
   phpunit_file:
@@ -22,6 +28,5 @@ runs:
   using: 'docker'
   image: 'docker://yireo/github-actions-magento-quick-integration-tests:latest'
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'green'
-

--- a/magento-quick-integration-tests/entrypoint.sh
+++ b/magento-quick-integration-tests/entrypoint.sh
@@ -2,13 +2,23 @@
 
 set -e
 
+test -z "${COMPOSER_NAME}" && COMPOSER_NAME=$INPUT_COMPOSER_NAME
+test -z "${MAGENTO_VERSION}" && MAGENTO_VERSION=$INPUT_MAGENTO_VERSION
+test -z "${MODULE_NAME}" && MODULE_NAME=$INPUT_MODULE_NAME
+test -z "${MODULE_SOURCE}" && MODULE_SOURCE=$INPUT_MODULE_SOURCE
+test -z "${PROJECT_NAME}" && PROJECT_NAME=$INPUT_PROJECT_NAME
+
+# Maintain backwards-compatibility with old 'ce_version' input.
+test -z "${MAGENTO_VERSION}" && MAGENTO_VERSION=$INPUT_CE_VERSION
+test -z "${MAGENTO_VERSION}" && MAGENTO_VERSION=$CE_VERSION
+
 test -z "${MODULE_NAME}" && (echo "'module_name' is not set in your GitHub Actions YAML file" && exit 1)
 test -z "${COMPOSER_NAME}" && (echo "'composer_name' is not set in your GitHub Actions YAML file" && exit 1)
-test -z "${CE_VERSION}" && (echo "'ce_version' is not set in your GitHub Actions YAML file" && exit 1)
+test -z "${MAGENTO_VERSION}" && (echo "'magento_version' is not set in your GitHub Actions YAML file" && exit 1)
 
 MAGENTO_ROOT=/tmp/m2
-PROJECT_PATH=$GITHUB_WORKSPACE
 test -z "${REPOSITORY_URL}" && REPOSITORY_URL="https://repo-magento-mirror.fooman.co.nz/"
+test -z "${PROJECT_NAME}" && PROJECT_NAME="magento/project-community-edition"
 
 echo "MySQL checks"
 nc -z -w1 mysql 3306 || (echo "MySQL is not running" && exit)
@@ -20,7 +30,7 @@ test -z "${MAGENTO_MARKETPLACE_USERNAME}" || composer global config http-basic.r
 
 echo "Prepare composer installation"
 composer global require hirak/prestissimo
-composer create-project --repository=$REPOSITORY_URL magento/project-community-edition:${CE_VERSION} $MAGENTO_ROOT --no-install --no-interaction --no-progress
+composer create-project --repository="$REPOSITORY_URL" "${PROJECT_NAME}:${MAGENTO_VERSION}" $MAGENTO_ROOT --no-install --no-interaction --no-progress
 
 echo "Setup extension source folder within Magento root"
 cd $MAGENTO_ROOT

--- a/magento-unit-tests/7.3/action.yml
+++ b/magento-unit-tests/7.3/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.4.0'
+  project_name:
+    description: 'Magento 2 project name'
+    required: true
+    default: 'magento/project-community-edition'
   module_source:
     description: 'Relative path to your module source within your repository. Empty by default.'
   phpunit_file:
@@ -26,6 +30,5 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-unit-tests-action:7.3-latest'
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'green'
-

--- a/magento-unit-tests/7.4/action.yml
+++ b/magento-unit-tests/7.4/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.4.3'
+  project_name:
+    description: 'Magento 2 project name'
+    required: true
+    default: 'magento/project-community-edition'
   module_source:
     description: 'Relative path to your module source within your repository. Empty by default.'
   phpunit_file:
@@ -26,6 +30,5 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-unit-tests-action:7.4-latest'
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'green'
-

--- a/magento-unit-tests/8.1/action.yml
+++ b/magento-unit-tests/8.1/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.4.4'
+  project_name:
+    description: 'Magento 2 project name'
+    required: true
+    default: 'magento/project-community-edition'
   module_source:
     description: 'Relative path to your module source within your repository, like "src/". Empty by default.'
   phpunit_file:
@@ -26,6 +30,5 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-unit-tests-action:8.1-latest'
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'green'
-

--- a/magento-unit-tests/8.2/action.yml
+++ b/magento-unit-tests/8.2/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Magento 2 Open Source version number'
     required: true
     default: '2.4.6-p3'
+  project_name:
+    description: 'Magento 2 project name'
+    required: true
+    default: 'magento/project-community-edition'
   module_source:
     description: 'Relative path to your module source within your repository, like "src/". Empty by default.'
   phpunit_file:

--- a/magento-unit-tests/entrypoint.sh
+++ b/magento-unit-tests/entrypoint.sh
@@ -2,9 +2,8 @@
 
 set -e
 
-test -z "${CE_VERSION}" || MAGENTO_VERSION=$CE_VERSION
-
 test -z "${MODULE_NAME}" && MODULE_NAME=$INPUT_MODULE_NAME
+test -z "${MODULE_SOURCE}" && MODULE_SOURCE=$INPUT_MODULE_SOURCE
 test -z "${COMPOSER_NAME}" && COMPOSER_NAME=$INPUT_COMPOSER_NAME
 test -z "${MAGENTO_VERSION}" && MAGENTO_VERSION=$INPUT_MAGENTO_VERSION
 test -z "${PROJECT_NAME}" && PROJECT_NAME=$INPUT_PROJECT_NAME
@@ -18,7 +17,6 @@ test -z "$PROJECT_NAME" && PROJECT_NAME="magento/project-community-edition"
 test -z "${MODULE_NAME}" && (echo "'module_name' is not set" && exit 1)
 test -z "${COMPOSER_NAME}" && (echo "'composer_name' is not set" && exit 1)
 test -z "${MAGENTO_VERSION}" && (echo "'magento_version' is not set" && exit 1)
-test -z "${PROJECT_NAME}" && (echo "'project_name' is not set" && exit 1)
 
 MAGENTO_ROOT=/tmp/m2
 PROJECT_PATH=$GITHUB_WORKSPACE


### PR DESCRIPTION
While reviewing #101, I noticed that the way that GitHub Actions "inputs" were handled was not consistent across all Actions in this repository. This pull request aims to make them consistent.

Changes include:
- Rename `ce_version` and `ce-version` inputs to `magento_version` (maintaining backwards-compatibility)
- Allow specifying `project_name` where `magento/project-community-edition` was hard-coded. Note that not all instances of this are fixed here.
- Unset extra environment variables in `action.yml` files for inputs
- Handle input variables in `entrypoint.sh` scripts as intended
- Remove unused inputs: `extension-name`, `extension-package-name`

Changes are best viewed with "ignore white-space" as my editor has removed trailing white-space in several files. If you would prefer these to remain as-is, please let me know and I will update the pull request accordingly.

Fixes #82
Closes #101