### PR TITLE
Check files within Magento project root

### DIFF
--- a/magento-phpstan/entrypoint.sh
+++ b/magento-phpstan/entrypoint.sh
@@ -9,8 +9,6 @@ if [ -z "$COMPOSER_VERSION" ] ; then
    COMPOSER_VERSION=2
 fi
 
-EXTENSION_BRANCH=${GITHUB_REF#refs/heads/}
-
 MAGENTO_ROOT=/m2
 test -z "${COMPOSER_NAME}" && (echo "'composer_name' is not set in your GitHub Actions YAML file" && exit 1)
 
@@ -43,17 +41,16 @@ fi;
 echo "Run installation"
 COMPOSER_MIRROR_PATH_REPOS=1 composer require $COMPOSER_NAME:@dev --no-interaction --dev
 
-CONFIGURATION_FILE=$MAGENTO_ROOT/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon
-test -f $GITHUB_WORKSPACE/${MODULE_SOURCE}/phpstan.neon && CONFIGURATION_FILE=$GITHUB_WORKSPACE/${MODULE_SOURCE}/phpstan.neon
+CONFIGURATION_FILE=dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon
+test -f vendor/${COMPOSER_NAME}/phpstan.neon && CONFIGURATION_FILE=vendor/${COMPOSER_NAME}/phpstan.neon
 
 echo "Configuration file: $CONFIGURATION_FILE"
 echo "Level: $INPUT_PHPSTAN_LEVEL"
 
 echo "Running PHPStan"
-cd ${GITHUB_WORKSPACE}/${MODULE_SOURCE}
-php $MAGENTO_ROOT/vendor/bin/phpstan analyse \
+php vendor/bin/phpstan analyse \
     --level $INPUT_PHPSTAN_LEVEL \
     --no-progress \
     --memory-limit=4G \
     --configuration ${CONFIGURATION_FILE} \
-    ${GITHUB_WORKSPACE}/${MODULE_SOURCE}
+    vendor/${COMPOSER_NAME}


### PR DESCRIPTION
While working on a Magento module with the PHPStan GitHub Action from this repository, I am getting some unexpected errors like "return statement is missing" when it isn't missing. I've done a little testing locally and when I inspect the same files within the Magento root, these extra errors don't show up. I have tested that (when I introduce an intentional issue) PHPStan still reports other issues with this set-up.

Here's an example run with invalid results https://github.com/Ethan3600/magento2-CronjobManager/actions/runs/8394567803/job/22992004531?pr=206