### PR TITLE
Allow usage of static encryption key

### DIFF
--- a/magento-integration-tests/7.0/action.yml
+++ b/magento-integration-tests/7.0/action.yml
@@ -36,6 +36,9 @@ inputs:
   magento_post_install_script:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
+  magento_encryption_key:
+    description: 'Static encryption key to be used during Magento installation.'
+    required: false
 runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:7.0-latest'

--- a/magento-integration-tests/7.1/action.yml
+++ b/magento-integration-tests/7.1/action.yml
@@ -36,6 +36,9 @@ inputs:
   magento_post_install_script:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
+  magento_encryption_key:
+    description: 'Static encryption key to be used during Magento installation.'
+    required: false
 runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:7.1-latest'

--- a/magento-integration-tests/7.2/action.yml
+++ b/magento-integration-tests/7.2/action.yml
@@ -36,6 +36,9 @@ inputs:
   magento_post_install_script:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
+  magento_encryption_key:
+    description: 'Static encryption key to be used during Magento installation.'
+    required: false
 runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:7.2-latest'

--- a/magento-integration-tests/7.3/action.yml
+++ b/magento-integration-tests/7.3/action.yml
@@ -36,6 +36,9 @@ inputs:
   magento_post_install_script:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
+  magento_encryption_key:
+    description: 'Static encryption key to be used during Magento installation.'
+    required: false
 runs:
   using: 'docker'
   image: 'docker://extdn/magento-integration-tests-action:7.3-latest'

--- a/magento-integration-tests/7.4/action.yml
+++ b/magento-integration-tests/7.4/action.yml
@@ -36,6 +36,9 @@ inputs:
   magento_post_install_script:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
+  magento_encryption_key:
+    description: 'Static encryption key to be used during Magento installation.'
+    required: false
   composer_version:
     description: 'The composer version to use. Can be either 1 or 2.'
     required: false

--- a/magento-integration-tests/8.1/action.yml
+++ b/magento-integration-tests/8.1/action.yml
@@ -36,6 +36,9 @@ inputs:
   magento_post_install_script:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
+  magento_encryption_key:
+    description: 'Static encryption key to be used during Magento installation.'
+    required: false
   composer_version:
     description: 'The composer version to use. Can be either 1 or 2.'
     required: false

--- a/magento-integration-tests/8.2/action.yml
+++ b/magento-integration-tests/8.2/action.yml
@@ -36,6 +36,9 @@ inputs:
   magento_post_install_script:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
+  magento_encryption_key:
+    description: 'Static encryption key to be used during Magento installation.'
+    required: false
   composer_version:
     description: 'The composer version to use. Can be either 1 or 2.'
     required: false

--- a/magento-integration-tests/8.3/action.yml
+++ b/magento-integration-tests/8.3/action.yml
@@ -36,6 +36,9 @@ inputs:
   magento_post_install_script:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
+  magento_encryption_key:
+    description: 'Static encryption key to be used during Magento installation.'
+    required: false
   composer_version:
     description: 'The composer version to use. Can be either 1 or 2.'
     required: false


### PR DESCRIPTION
Magento allows you to specify an encryption key during the application installation. This PR aims to provide this same ability during the setup.

The reason behind this is that a client has a specific test case that relies on data generated using an encryption key. This data is partially stored (statically) in an external service. To ensure the correct outcome I need to be able to specify the encryption key so the resulting encrypted value is not random.