### PR TITLE
Build PHPStan image after its parent completes

### DIFF
--- a/.github/workflows/phpstan-images.yml
+++ b/.github/workflows/phpstan-images.yml
@@ -7,6 +7,13 @@ on:
       - master
     paths:
       - 'magento-phpstan/**'
+  workflow_run:
+    workflows:
+      - Build Integration Images
+    types:
+      - completed
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
The automated build for the PHPStan image failed because it depends on the integration test image, which didn't exist at the time. Moments later, it did exist, so this build will work next time it runs.

This change allows the build to work properly, and also rebuilds these images when the upstream/parent image gets any changes - like adding a PHP extension.