### PR TITLE
Rebuild all images weekly

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,8 @@ name: Docker Build
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 0" # 6 AM Weekly
   release:
     types: [published]
 

--- a/.github/workflows/integration-test-images.yml
+++ b/.github/workflows/integration-test-images.yml
@@ -2,6 +2,8 @@ name: Build Integration Images
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 0" # 6 AM Weekly
   push:
     branches:
       - master

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -2,6 +2,8 @@ name: Build PHP compatibility Images
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 0" # 6 AM Weekly
   push:
     branches:
       - master

--- a/.github/workflows/phpstan-images.yml
+++ b/.github/workflows/phpstan-images.yml
@@ -2,6 +2,8 @@ name: Build PHPStan Images
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 0" # 6 AM Weekly
   push:
     branches:
       - master

--- a/.github/workflows/unit-test-images.yml
+++ b/.github/workflows/unit-test-images.yml
@@ -2,6 +2,8 @@ name: Build Unit Testing Images
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 0" # 6 AM Weekly
   push:
     branches:
       - master


### PR DESCRIPTION
We already rebuild the coding standard image weekly. Let's also rebuild other images weekly. This allows us to better detect when upstream breaks something that we need to adjust our images in order to accommodate.