### PR TITLE
Fix 2.4.8 integration tests

### DIFF
--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -109,9 +109,14 @@ SETUP_ARGS="--base-url=http://magento2.test/ \
 --sales-order-increment-prefix=ORD_ --session-save=db \
 --use-rewrites=1"
 
+SEARCH_ENGINE_VERSION="elasticsearch7"
+if [[ "$MAGE_VERSION" == 2.4.8* ]]; then
+  SEARCH_ENGINE_VERSION="elasticsearch8"
+fi
+
 # only add the --search-engine param if it is supported
 if bin/magento setup:install --help | grep -q '\-\-search\-engine='; then
-    SETUP_ARGS="$SETUP_ARGS --search-engine=elasticsearch7"
+    SETUP_ARGS="$SETUP_ARGS --search-engine=$SEARCH_ENGINE_VERSION"
 fi
 
 if [[ "$ELASTICSEARCH" == "1" ]]; then

--- a/magento-quick-integration-tests/entrypoint.sh
+++ b/magento-quick-integration-tests/entrypoint.sh
@@ -68,9 +68,14 @@ SETUP_ARGS="--base-url=http://magento2.test/ \
 --sales-order-increment-prefix=ORD_ --session-save=db \
 --use-rewrites=1"
 
+SEARCH_ENGINE_VERSION="elasticsearch7"
+if [[ "$MAGENTO_VERSION" == 2.4.8* ]]; then
+  SEARCH_ENGINE_VERSION="elasticsearch8"
+fi
+
 # only add the --search-engine param if it is supported
 if bin/magento setup:install --help | grep -q '\-\-search\-engine='; then
-    SETUP_ARGS="$SETUP_ARGS --search-engine=elasticsearch7"
+    SETUP_ARGS="$SETUP_ARGS --search-engine=$SEARCH_ENGINE_VERSION"
 fi
 
 if [[ "$ELASTICSEARCH" == "1" ]]; then


### PR DESCRIPTION
Here's my best guess at fixing the 2.4.8 integration tests.

In 2.4.8 there is no longer an `elasticsearch7` option

https://github.com/magento/magento2/blob/eb491c0533c106ca44ee219c545c617f53aea2bc/setup/src/Magento/Setup/Model/SearchConfigOptionsList.php#L149-L155

I have generated a failing test example on [this repo](https://github.com/convenient/magento-github-actions-test) and the failure can be seen in [this run](https://github.com/convenient/magento-github-actions-test/actions/runs/14704692563/job/41262032689).

It fails to install with 
```
[Progress: 735 / 1477]
Installing search configuration...
In SearchConfig.php line 97:
                                                                     
  Search engine 'elasticsearch7' is not an available search engine.  
```

Additionally, i think this file is baked into the docker image. Any tips for how I can properly test out my changes? 