### PR TITLE
Remove support for Composer v1

### DIFF
--- a/examples/extdn-integration-tests-with-elasticsearch.yml
+++ b/examples/extdn-integration-tests-with-elasticsearch.yml
@@ -30,20 +30,15 @@ jobs:
       - uses: extdn/github-actions-m2/magento-integration-tests/7.4@master
         env:
           MAGENTO_VERSION: '2.4.3-p2'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-integration-tests/8.1@master
         env:
           MAGENTO_VERSION: '2.4.4'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-integration-tests/8.2@master
         env:
           MAGENTO_VERSION: '2.4.6-p3'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-integration-tests/8.3@master
         env:
           MAGENTO_VERSION: '2.4.7'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-integration-tests/8.4@master
         env:
           MAGENTO_VERSION: '2.4.8'
-          COMPOSER_VERSION: '2'

--- a/examples/extdn-integration-tests-with-marketplace.yml
+++ b/examples/extdn-integration-tests-with-marketplace.yml
@@ -34,20 +34,15 @@ jobs:
       - uses: extdn/github-actions-m2/magento-integration-tests/7.4@master
         env:
           MAGENTO_VERSION: '2.4.3-p2'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-integration-tests/8.1@master
         env:
           MAGENTO_VERSION: '2.4.4'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-integration-tests/8.2@master
         env:
           MAGENTO_VERSION: '2.4.6-p3'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-integration-tests/8.3@master
         env:
           MAGENTO_VERSION: '2.4.7'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-integration-tests/8.4@master
         env:
           MAGENTO_VERSION: '2.4.8'
-          COMPOSER_VERSION: '2'

--- a/examples/extdn-integration-tests.yml
+++ b/examples/extdn-integration-tests.yml
@@ -24,20 +24,15 @@ jobs:
       - uses: extdn/github-actions-m2/magento-integration-tests/7.4@master
         env:
           MAGENTO_VERSION: '2.4.3-p2'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-integration-tests/8.1@master
         env:
           MAGENTO_VERSION: '2.4.4'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-integration-tests/8.2@master
         env:
           MAGENTO_VERSION: '2.4.6-p3'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-integration-tests/8.3@master
         env:
           MAGENTO_VERSION: '2.4.7'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-integration-tests/8.4@master
         env:
           MAGENTO_VERSION: '2.4.8'
-          COMPOSER_VERSION: '2'

--- a/examples/extdn-phpstan.yml
+++ b/examples/extdn-phpstan.yml
@@ -8,7 +8,6 @@ jobs:
     env:
       COMPOSER_NAME: ${{ secrets.COMPOSER_NAME }}
       PHPSTAN_LEVEL: 2
-      COMPOSER_VERSION: 2
     steps:
       - uses: actions/checkout@v4
       - uses: extdn/github-actions-m2/magento-phpstan/8.4@master

--- a/examples/extdn-unit-tests.yml
+++ b/examples/extdn-unit-tests.yml
@@ -19,16 +19,12 @@ jobs:
       - uses: extdn/github-actions-m2/magento-unit-tests/8.1@master
         env:
           MAGENTO_VERSION: '2.4.4'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-unit-tests/8.2@master
         env:
           MAGENTO_VERSION: '2.4.6-p3'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-unit-tests/8.3@master
         env:
           MAGENTO_VERSION: '2.4.7'
-          COMPOSER_VERSION: '2'
       - uses: extdn/github-actions-m2/magento-unit-tests/8.4@master
         env:
           MAGENTO_VERSION: '2.4.8'
-          COMPOSER_VERSION: '2'

--- a/magento-copy-paste-detector/Dockerfile
+++ b/magento-copy-paste-detector/Dockerfile
@@ -1,10 +1,10 @@
 FROM extdn/magento-integration-tests-action:7.3-latest AS builder
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer1 create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.1"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.1"
 WORKDIR "/var/www/magento2ce"
-RUN composer1 config --unset repo.0
-RUN composer1 config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
-RUN composer1 install --prefer-dist
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer install --prefer-dist
 
 FROM extdn/magento-integration-tests-action:7.4-latest
 COPY --from=builder /var/www/magento2ce/ /m2/

--- a/magento-integration-tests/7.4/action.yml
+++ b/magento-integration-tests/7.4/action.yml
@@ -37,7 +37,7 @@ inputs:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
   composer_version:
-    description: 'The composer version to use. Can be either 1 or 2.'
+    description: 'DEPREACATED. Composer v2 is now always used.'
     required: false
     default: '1'
 runs:

--- a/magento-integration-tests/8.1/action.yml
+++ b/magento-integration-tests/8.1/action.yml
@@ -37,7 +37,7 @@ inputs:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
   composer_version:
-    description: 'The composer version to use. Can be either 1 or 2.'
+    description: 'DEPREACATED. Composer v2 is now always used.'
     required: false
     default: '1'
 runs:

--- a/magento-integration-tests/8.2/action.yml
+++ b/magento-integration-tests/8.2/action.yml
@@ -37,7 +37,7 @@ inputs:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
   composer_version:
-    description: 'The composer version to use. Can be either 1 or 2.'
+    description: 'DEPREACATED. Composer v2 is now always used.'
     required: false
     default: '2'
 runs:

--- a/magento-integration-tests/8.3/action.yml
+++ b/magento-integration-tests/8.3/action.yml
@@ -37,7 +37,7 @@ inputs:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
   composer_version:
-    description: 'The composer version to use. Can be either 1 or 2.'
+    description: 'DEPREACATED. Composer v2 is now always used.'
     required: false
     default: '2'
 runs:

--- a/magento-integration-tests/8.4/action.yml
+++ b/magento-integration-tests/8.4/action.yml
@@ -37,7 +37,7 @@ inputs:
     description: 'Relative path to an optional script after Magento installation is run. Leave empty to use the default.'
     required: false
   composer_version:
-    description: 'The composer version to use. Can be either 1 or 2.'
+    description: 'DEPREACATED. Composer v2 is now always used.'
     required: false
     default: '2'
 runs:

--- a/magento-integration-tests/Dockerfile:7.0
+++ b/magento-integration-tests/Dockerfile:7.0
@@ -1,6 +1,6 @@
 FROM php:7.0-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN grep -v security.debian.org /etc/apt/sources.list | grep -v stretch-updates | sed -e 's/deb.debian.org/archive.debian.org/' > /t && mv /t /etc/apt/sources.list
 RUN apt-get update && apt-get -y install --no-install-recommends \
@@ -37,7 +37,6 @@ RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
-RUN /usr/local/bin/composer1 global require hirak/prestissimo
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh

--- a/magento-integration-tests/Dockerfile:7.1
+++ b/magento-integration-tests/Dockerfile:7.1
@@ -1,6 +1,6 @@
 FROM php:7.1-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \
@@ -36,7 +36,6 @@ RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
-RUN /usr/local/bin/composer1 global require hirak/prestissimo
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh

--- a/magento-integration-tests/Dockerfile:7.2
+++ b/magento-integration-tests/Dockerfile:7.2
@@ -1,6 +1,6 @@
 FROM php:7.2-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \
@@ -36,7 +36,6 @@ RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
-RUN /usr/local/bin/composer1 global require hirak/prestissimo
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh

--- a/magento-integration-tests/Dockerfile:7.3
+++ b/magento-integration-tests/Dockerfile:7.3
@@ -1,7 +1,6 @@
 FROM php:7.3-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer2
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \
@@ -37,7 +36,6 @@ RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install sockets
-RUN /usr/local/bin/composer1 global require hirak/prestissimo
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh

--- a/magento-integration-tests/Dockerfile:7.4
+++ b/magento-integration-tests/Dockerfile:7.4
@@ -1,7 +1,6 @@
 FROM php:7.4-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer2
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \

--- a/magento-integration-tests/Dockerfile:8.1
+++ b/magento-integration-tests/Dockerfile:8.1
@@ -1,7 +1,6 @@
 FROM php:8.1-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer2
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \

--- a/magento-integration-tests/Dockerfile:8.2
+++ b/magento-integration-tests/Dockerfile:8.2
@@ -1,7 +1,6 @@
 FROM php:8.2-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer2
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \

--- a/magento-integration-tests/Dockerfile:8.3
+++ b/magento-integration-tests/Dockerfile:8.3
@@ -1,7 +1,6 @@
 FROM php:8.3-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer2
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \

--- a/magento-integration-tests/Dockerfile:8.4
+++ b/magento-integration-tests/Dockerfile:8.4
@@ -1,7 +1,6 @@
 FROM php:8.4-cli
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer1
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer2
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     mariadb-client \

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -9,7 +9,6 @@ test -z "${MAGENTO_VERSION}" && MAGENTO_VERSION=$INPUT_MAGENTO_VERSION
 test -z "${PROJECT_NAME}" && PROJECT_NAME=$INPUT_PROJECT_NAME
 test -z "${ELASTICSEARCH}" && ELASTICSEARCH=$INPUT_ELASTICSEARCH
 test -z "${PHPUNIT_FILE}" && PHPUNIT_FILE=$INPUT_PHPUNIT_FILE
-test -z "${COMPOSER_VERSION}" && COMPOSER_VERSION=$INPUT_COMPOSER_VERSION
 test -z "${REPOSITORY_URL}" && REPOSITORY_URL=$INPUT_REPOSITORY_URL
 
 # Maintain backwards-compatibility with old 'ce_version' input.
@@ -17,8 +16,6 @@ test -z "${MAGENTO_VERSION}" && MAGENTO_VERSION=$INPUT_CE_VERSION
 test -z "${MAGENTO_VERSION}" && MAGENTO_VERSION=$CE_VERSION
 
 test -z "$MAGENTO_VERSION" && MAGENTO_VERSION="2.4.3-p1"
-test -z "$COMPOSER_VERSION" && [[ "$MAGENTO_VERSION" =~ ^2.4.* ]] && COMPOSER_VERSION=2
-test -z "$COMPOSER_VERSION" && COMPOSER_VERSION=2
 test -z "$PROJECT_NAME" && PROJECT_NAME="magento/project-community-edition"
 test -z "${REPOSITORY_URL}" && REPOSITORY_URL="https://repo-magento-mirror.fooman.co.nz/"
 
@@ -34,8 +31,6 @@ MAGENTO_ROOT=/var/www/magento2ce
 PROJECT_PATH=$GITHUB_WORKSPACE
 
 echo "Using Magento root ${MAGENTO_ROOT}"
-echo "Using composer ${COMPOSER_VERSION}"
-ln -s /usr/local/bin/composer$COMPOSER_VERSION /usr/local/bin/composer
 
 echo "Pre Project Script [pre_project_script]: $INPUT_PRE_PROJECT_SCRIPT"
 if [[ ! -z "$INPUT_PRE_PROJECT_SCRIPT" && -f "${GITHUB_WORKSPACE}/$INPUT_PRE_PROJECT_SCRIPT" ]] ; then
@@ -79,10 +74,8 @@ if [[ ! -z "$INPUT_MAGENTO_PRE_INSTALL_SCRIPT" && -f "${GITHUB_WORKSPACE}/$INPUT
     . ${GITHUB_WORKSPACE}/$INPUT_MAGENTO_PRE_INSTALL_SCRIPT
 fi
 
-if [[ "$COMPOSER_VERSION" -eq "2" ]] ; then
-    echo "Allow composer plugins"
-    composer config --no-plugins allow-plugins true
-fi
+echo "Allow composer plugins"
+composer config --no-plugins allow-plugins true
 
 if [[ "$MAGENTO_VERSION" == "2.4.4" ]]; then
     echo "Quick fix for Magento 2.4.4"

--- a/magento-mess-detector/Dockerfile
+++ b/magento-mess-detector/Dockerfile
@@ -1,10 +1,10 @@
 FROM extdn/magento-integration-tests-action:7.4-latest AS builder
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer1 create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.1"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.1"
 WORKDIR "/var/www/magento2ce"
-RUN composer1 config --unset repo.0
-RUN composer1 config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
-RUN composer1 install --prefer-dist
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer install --prefer-dist
 
 
 FROM extdn/magento-integration-tests-action:7.4-latest

--- a/magento-phpstan/7.3/action.yml
+++ b/magento-phpstan/7.3/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: "1"
     required: false
   composer_version:
-    description: 'The composer version to use. Can be either 1 or 2.'
+    description: 'DEPREACATED. Composer v2 is now always used.'
     required: false
     default: "1"
   magento_pre_install_script:
@@ -23,5 +23,5 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-phpstan-action:7.3-latest'
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'green'

--- a/magento-phpstan/7.4/action.yml
+++ b/magento-phpstan/7.4/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: "1"
     required: false
   composer_version:
-    description: 'The composer version to use. Can be either 1 or 2.'
+    description: 'DEPREACATED. Composer v2 is now always used.'
     required: false
     default: "2"
   magento_pre_install_script:
@@ -23,5 +23,5 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-phpstan-action:7.4-latest'
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'green'

--- a/magento-phpstan/8.1/action.yml
+++ b/magento-phpstan/8.1/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: "1"
     required: false
   composer_version:
-    description: 'The composer version to use. Can be either 1 or 2.'
+    description: 'DEPREACATED. Composer v2 is now always used.'
     required: false
     default: "2"
   magento_pre_install_script:
@@ -23,5 +23,5 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-phpstan-action:8.1-latest'
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'green'

--- a/magento-phpstan/8.2/action.yml
+++ b/magento-phpstan/8.2/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: "1"
     required: false
   composer_version:
-    description: 'The composer version to use. Can be either 1 or 2.'
+    description: 'DEPREACATED. Composer v2 is now always used.'
     required: false
     default: "2"
   magento_pre_install_script:

--- a/magento-phpstan/8.3/action.yml
+++ b/magento-phpstan/8.3/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: "1"
     required: false
   composer_version:
-    description: 'The composer version to use. Can be either 1 or 2.'
+    description: 'DEPREACATED. Composer v2 is now always used.'
     required: false
     default: "2"
   magento_pre_install_script:

--- a/magento-phpstan/8.4/action.yml
+++ b/magento-phpstan/8.4/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: "1"
     required: false
   composer_version:
-    description: 'The composer version to use. Can be either 1 or 2.'
+    description: 'DEPREACATED. Composer v2 is now always used.'
     required: false
     default: "2"
   magento_pre_install_script:

--- a/magento-phpstan/action.yml
+++ b/magento-phpstan/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: "1"
     required: false
   composer_version:
-    description: 'The composer version to use. Can be either 1 or 2.'
+    description: 'DEPREACATED. Composer v2 is now always used.'
     required: false
     default: "2"
   magento_pre_install_script:
@@ -23,5 +23,5 @@ runs:
   using: 'docker'
   image: 'docker://extdn/magento-phpstan-action:latest'
 branding:
-  icon: 'code'  
+  icon: 'code'
   color: 'red'

--- a/magento-phpstan/entrypoint.sh
+++ b/magento-phpstan/entrypoint.sh
@@ -4,17 +4,12 @@ set -e
 test -z "${MODULE_SOURCE}" && MODULE_SOURCE=$INPUT_MODULE_SOURCE
 test -z "${COMPOSER_NAME}" && COMPOSER_NAME=$INPUT_COMPOSER_NAME
 test -z "${PHPSTAN_LEVEL}" && PHPSTAN_LEVEL=$INPUT_PHPSTAN_LEVEL
-test -z "${COMPOSER_VERSION}" && COMPOSER_VERSION=$INPUT_COMPOSER_VERSION
-test -z "${COMPOSER_VERSION}" && COMPOSER_VERSION=2
 
 MAGENTO_ROOT=/var/www/magento2ce
 test -d "${MAGENTO_ROOT}" || (test -d /var/www/magento2ce && MAGENTO_ROOT=/tmp/m2)
 echo "Using Magento root ${MAGENTO_ROOT}"
 
 test -z "${COMPOSER_NAME}" && (echo "'composer_name' is not set in your GitHub Actions YAML file" && exit 1)
-
-echo "Using composer ${COMPOSER_VERSION}"
-ln -s /usr/local/bin/composer$COMPOSER_VERSION /usr/local/bin/composer
 
 echo "Setup extension source folder within Magento root"
 mkdir -p $MAGENTO_ROOT/local-source/

--- a/magento-quick-integration-tests/Dockerfile
+++ b/magento-quick-integration-tests/Dockerfile
@@ -1,7 +1,6 @@
 FROM php:7.3
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer2
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update && apt-get -y install \
     mariadb-client \
@@ -36,4 +35,3 @@ RUN chmod 755 /entrypoint.sh
 COPY docker-files /docker-files
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
-

--- a/magento-quick-integration-tests/entrypoint.sh
+++ b/magento-quick-integration-tests/entrypoint.sh
@@ -29,7 +29,6 @@ echo "Setup Magento credentials"
 test -z "${MAGENTO_MARKETPLACE_USERNAME}" || composer global config http-basic.repo.magento.com $MAGENTO_MARKETPLACE_USERNAME $MAGENTO_MARKETPLACE_PASSWORD
 
 echo "Prepare composer installation"
-composer global require hirak/prestissimo
 composer create-project --repository="$REPOSITORY_URL" "${PROJECT_NAME}:${MAGENTO_VERSION}" $MAGENTO_ROOT --no-install --no-interaction --no-progress
 
 echo "Setup extension source folder within Magento root"

--- a/magento-unit-tests/Dockerfile:7.2
+++ b/magento-unit-tests/Dockerfile:7.2
@@ -1,6 +1,6 @@
 FROM php:7.2
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update && apt-get -y install \
     mariadb-client \
@@ -33,7 +33,6 @@ RUN docker-php-ext-install sodium
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install sockets
-RUN composer global require hirak/prestissimo
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
@@ -41,4 +40,3 @@ RUN chmod 755 /entrypoint.sh
 COPY docker-files /docker-files
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
-

--- a/magento-unit-tests/Dockerfile:7.3
+++ b/magento-unit-tests/Dockerfile:7.3
@@ -1,7 +1,6 @@
 FROM php:7.3
 
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer2
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update && apt-get -y install \
     mariadb-client \
@@ -34,7 +33,6 @@ RUN docker-php-ext-install sodium
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install sockets
-RUN composer global require hirak/prestissimo
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
@@ -42,4 +40,3 @@ RUN chmod 755 /entrypoint.sh
 COPY docker-files /docker-files
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
-

--- a/magento-unit-tests/entrypoint.sh
+++ b/magento-unit-tests/entrypoint.sh
@@ -10,8 +10,6 @@ test -z "${PROJECT_NAME}" && PROJECT_NAME=$INPUT_PROJECT_NAME
 test -z "${PHPUNIT_FILE}" && PHPUNIT_FILE=$INPUT_PHPUNIT_FILE
 
 test -z "$MAGENTO_VERSION" && MAGENTO_VERSION="2.4.4"
-test -z "$COMPOSER_VERSION" && [[ "$MAGENTO_VERSION" =~ ^2.4.* ]] && COMPOSER_VERSION=2
-test -z "$COMPOSER_VERSION" && COMPOSER_VERSION=1
 test -z "$PROJECT_NAME" && PROJECT_NAME="magento/project-community-edition"
 
 test -z "${MODULE_NAME}" && (echo "'module_name' is not set" && exit 1)
@@ -47,10 +45,8 @@ if [[ ! -z "$INPUT_MAGENTO_PRE_INSTALL_SCRIPT" && -f "${GITHUB_WORKSPACE}/$INPUT
     . ${GITHUB_WORKSPACE}/$INPUT_MAGENTO_PRE_INSTALL_SCRIPT
 fi
 
-if [[ "$COMPOSER_VERSION" -eq "2" ]] ; then
-    echo "Allow composer plugins"
-    composer config --no-plugins allow-plugins true
-fi
+echo "Allow composer plugins"
+composer config --no-plugins allow-plugins true
 
 echo "Run installation"
 COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist --no-interaction --no-progress


### PR DESCRIPTION
As of 1st August, Composer v1 will stop working. In anticipation of this, this pull request removes support for Composer v1.

https://blog.packagist.com/shutting-down-packagist-org-support-for-composer-1-x/