### PR TITLE
Correct command name for composer

### DIFF
--- a/magento-phpstan/Dockerfile
+++ b/magento-phpstan/Dockerfile
@@ -1,14 +1,14 @@
 FROM extdn/magento-integration-tests-action:7.4-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer2 create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.3-p2"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.3-p2"
 
 WORKDIR "/var/www/magento2ce"
-RUN composer2 config --no-plugins allow-plugins true
-RUN composer2 config --unset repo.0
-RUN composer2 config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
-RUN composer2 require hoa/regex --no-update
-RUN composer2 install --prefer-dist
+RUN composer config --no-plugins allow-plugins true
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer require hoa/regex --no-update
+RUN composer install --prefer-dist
 
 FROM extdn/magento-integration-tests-action:7.4-latest
 COPY --from=builder /var/www/magento2ce/ /m2/

--- a/magento-phpstan/Dockerfile:7.3
+++ b/magento-phpstan/Dockerfile:7.3
@@ -1,14 +1,14 @@
 FROM extdn/magento-integration-tests-action:7.3-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer2 create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.3.7-p3"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.3.7-p3"
 
 WORKDIR "/var/www/magento2ce"
-RUN composer2 config --unset repo.0
-RUN composer2 config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
-RUN composer2 config --no-plugins allow-plugins true
-RUN composer2 require hoa/regex --no-update
-RUN composer2 install --prefer-dist
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer install --prefer-dist
 
 FROM extdn/magento-integration-tests-action:7.3-latest
 COPY --from=builder /var/www/magento2ce/ /m2/

--- a/magento-phpstan/Dockerfile:7.4
+++ b/magento-phpstan/Dockerfile:7.4
@@ -1,14 +1,14 @@
 FROM extdn/magento-integration-tests-action:7.4-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer2 create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.3-p2"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.3-p2"
 
 WORKDIR "/var/www/magento2ce"
-RUN composer2 config --unset repo.0
-RUN composer2 config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
-RUN composer2 config --no-plugins allow-plugins true
-RUN composer2 require hoa/regex --no-update
-RUN composer2 install --prefer-dist
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer install --prefer-dist
 
 FROM extdn/magento-integration-tests-action:7.4-latest
 COPY --from=builder /var/www/magento2ce/ /m2/

--- a/magento-phpstan/Dockerfile:8.1
+++ b/magento-phpstan/Dockerfile:8.1
@@ -1,14 +1,14 @@
 FROM extdn/magento-integration-tests-action:8.1-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer2 create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.4"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.4"
 
 WORKDIR "/var/www/magento2ce"
-RUN composer2 config --unset repo.0
-RUN composer2 config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
-RUN composer2 config --no-plugins allow-plugins true
-RUN composer2 require hoa/regex --no-update
-RUN composer2 install --prefer-dist
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer install --prefer-dist
 
 FROM extdn/magento-integration-tests-action:8.1-latest
 COPY --from=builder /var/www/magento2ce/ /m2/

--- a/magento-phpstan/Dockerfile:8.2
+++ b/magento-phpstan/Dockerfile:8.2
@@ -1,14 +1,14 @@
 FROM extdn/magento-integration-tests-action:8.2-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer2 create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.6-p3"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.6-p3"
 
 WORKDIR "/var/www/magento2ce"
-RUN composer2 config --unset repo.0
-RUN composer2 config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
-RUN composer2 config --no-plugins allow-plugins true
-RUN composer2 require hoa/regex --no-update
-RUN composer2 install --prefer-dist
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer install --prefer-dist
 
 FROM extdn/magento-integration-tests-action:8.2-latest
 COPY --from=builder /var/www/magento2ce/ /m2/

--- a/magento-phpstan/Dockerfile:8.3
+++ b/magento-phpstan/Dockerfile:8.3
@@ -1,14 +1,14 @@
 FROM extdn/magento-integration-tests-action:8.3-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer2 create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.7"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.7"
 
 WORKDIR "/var/www/magento2ce"
-RUN composer2 config --unset repo.0
-RUN composer2 config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
-RUN composer2 config --no-plugins allow-plugins true
-RUN composer2 require hoa/regex --no-update
-RUN composer2 install --prefer-dist
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer install --prefer-dist
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/magento-phpstan/Dockerfile:8.4
+++ b/magento-phpstan/Dockerfile:8.4
@@ -1,14 +1,14 @@
 FROM extdn/magento-integration-tests-action:8.4-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer2 create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8"
 
 WORKDIR "/var/www/magento2ce"
-RUN composer2 config --unset repo.0
-RUN composer2 config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
-RUN composer2 config --no-plugins allow-plugins true
-RUN composer2 require hoa/regex --no-update
-RUN composer2 install --prefer-dist
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer install --prefer-dist
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This is a follow-up to a4b11d149919c38a226409b1d4d667526f37d57b (merged as #124) where we dropped support for Composer v1 and renamed Composer v2 to just 'composer'.

Thanks to @sprankhub for highlighting this bug to me.