### PR TITLE
Use configured version of elasticsearch

### DIFF
--- a/magento-integration-tests/docker-files/install-config-mysql-with-es.php
+++ b/magento-integration-tests/docker-files/install-config-mysql-with-es.php
@@ -11,7 +11,7 @@ return [
     'admin-email' => \Magento\TestFramework\Bootstrap::ADMIN_EMAIL,
     'admin-firstname' => \Magento\TestFramework\Bootstrap::ADMIN_FIRSTNAME,
     'admin-lastname' => \Magento\TestFramework\Bootstrap::ADMIN_LASTNAME,
-    'search-engine' => 'elasticsearch7',
+    'search-engine' => '{{SEARCH_ENGINE_VERSION}}',
     'elasticsearch-host' => 'es',
     'elasticsearch-port' => '9200',
 ];

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -139,7 +139,7 @@ echo "Prepare for integration tests"
 cd $MAGENTO_ROOT
 cp /docker-files/install-config-mysql.php dev/tests/integration/etc/install-config-mysql.php
 if [[ "$ELASTICSEARCH" == "1" ]]; then
-    cp /docker-files/install-config-mysql-with-es.php dev/tests/integration/etc/install-config-mysql.php
+    sed -e "s/{{SEARCH_ENGINE_VERSION}}/$SEARCH_ENGINE_VERSION/" < /docker-files/install-config-mysql-with-es.php > dev/tests/integration/etc/install-config-mysql.php
 fi
 
 sed "s#%COMPOSER_NAME%#$COMPOSER_NAME#g" $PHPUNIT_FILE > dev/tests/integration/phpunit.xml


### PR DESCRIPTION
This is a follow-up to #123 where we added the ability to use elasticsearch8 instead of elasticsearch7 on Magento 2.4.8. I'm getting errors about this configuration downstream.

Example action failure: https://github.com/Ethan3600/magento2-CronjobManager/actions/runs/14779752203/job/41495908405