### PR TITLE
Attempt to use phpunit 10 compatible event system

### DIFF
--- a/magento-integration-tests/docker-files/phpunitv10.xml
+++ b/magento-integration-tests/docker-files/phpunitv10.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+         colors="true"
+         columns="max"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="./framework/bootstrap.php"
+         stderr="true">
+    <source>
+        <exclude>
+            <directory>../../../app/code/*/*/Test</directory>
+            <directory>../../../lib/internal/*/*/Test</directory>
+            <directory>../../../lib/internal/*/*/*/Test</directory>
+            <directory>../../../setup/src/*/*/Test</directory>
+        </exclude>
+    </source>
+    <!-- Test suites definition -->
+    <testsuites>
+        <testsuite name="IntegrationTests">
+            <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/Test/Integration</directory>
+            <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/tests/Integration</directory>
+            <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/tests/integration</directory>
+            <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/src/Test/Integration</directory>
+            <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/src/tests/Integration</directory>
+            <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/src/tests/integration</directory>
+        </testsuite>
+    </testsuites>
+    <!-- Code coverage filters -->
+    <!-- PHP INI settings and constants definition -->
+    <php>
+        <includePath>.</includePath>
+        <includePath>testsuite</includePath>
+        <ini name="date.timezone" value="America/Los_Angeles"/>
+        <ini name="xdebug.max_nesting_level" value="200"/>
+        <ini name="memory_limit" value="-1"/>
+        <!-- Local XML configuration file ('.dist' extension will be added, if the specified file doesn't exist) -->
+        <const name="TESTS_INSTALL_CONFIG_FILE" value="etc/install-config-mysql.php"/>
+        <!-- Local XML post installation configuration file ('.dist' extension will be added, if the specified file doesn't exist) -->
+        <const name="TESTS_POST_INSTALL_SETUP_COMMAND_CONFIG_FILE" value="etc/post-install-setup-command-config.php"/>
+        <!-- Local XML configuration file ('.dist' extension will be added, if the specified file doesn't exist) -->
+        <const name="TESTS_GLOBAL_CONFIG_FILE" value="etc/config-global.php"/>
+        <!-- Semicolon-separated 'glob' patterns, that match global XML configuration files -->
+        <const name="TESTS_GLOBAL_CONFIG_DIR" value="../../../app/etc"/>
+        <!-- Whether to cleanup the application before running tests or not -->
+        <const name="TESTS_CLEANUP" value="enabled"/>
+        <!-- Memory usage and estimated leaks thresholds -->
+        <!--<const name="TESTS_MEM_USAGE_LIMIT" value="1024M"/>-->
+        <const name="TESTS_MEM_LEAK_LIMIT" value=""/>
+        <!-- Path to Percona Toolkit bin directory -->
+        <!--<const name="PERCONA_TOOLKIT_BIN_DIR" value=""/>-->
+        <!-- CSV Profiler Output file -->
+        <!--<const name="TESTS_PROFILER_FILE" value="profiler.csv"/>-->
+        <!-- Bamboo compatible CSV Profiler Output file name -->
+        <!--<const name="TESTS_BAMBOO_PROFILER_FILE" value="profiler.csv"/>-->
+        <!-- Metrics for Bamboo Profiler Output in PHP file that returns array -->
+        <!--<const name="TESTS_BAMBOO_PROFILER_METRICS_FILE" value="../../build/profiler_metrics.php"/>-->
+        <!-- Whether to output all CLI commands executed by the bootstrap and tests -->
+        <const name="TESTS_EXTRA_VERBOSE_LOG" value="1"/>
+        <!-- Magento mode for tests execution. Possible values are "default", "developer" and "production". -->
+        <const name="TESTS_MAGENTO_MODE" value="developer"/>
+        <!-- Minimum error log level to listen for. Possible values: -1 ignore all errors, and level constants form http://tools.ietf.org/html/rfc5424 standard -->
+        <const name="TESTS_ERROR_LOG_LISTENER_LEVEL" value="-1"/>
+        <!-- Connection parameters for MongoDB library tests -->
+        <!--<const name="MONGODB_CONNECTION_STRING" value="mongodb://localhost:27017"/>-->
+        <!--<const name="MONGODB_DATABASE_NAME" value="magento_integration_tests"/>-->
+        <!-- Connection parameters for RabbitMQ tests -->
+        <!--<const name="RABBITMQ_MANAGEMENT_PROTOCOL" value="https"/>-->
+        <!--<const name="RABBITMQ_MANAGEMENT_PORT" value="15672"/>-->
+        <!--<const name="RABBITMQ_VIRTUALHOST" value="/"/>-->
+        <!--<const name="TESTS_PARALLEL_RUN" value="1"/>-->
+        <const name="USE_OVERRIDE_CONFIG" value="enabled"/>
+    </php>
+    <extensions>
+        <bootstrap class="Qameta\Allure\PHPUnit\AllureExtension">
+            <!-- Path to config file (default is config/allure.config.php) -->
+            <parameter name="config" value="allure/allure.config.php" />
+        </bootstrap>
+        <bootstrap class="Magento\TestFramework\Event\Subscribers"/>
+    </extensions>
+</phpunit>

--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -131,7 +131,11 @@ if [[ ! -z "$PHPUNIT_FILE" ]] ; then
 fi
 
 if [[ ! -f "$PHPUNIT_FILE" ]] ; then
-    PHPUNIT_FILE=/docker-files/phpunit.xml
+    if [[ "$MAGENTO_VERSION" == 2.4.8* ]]; then
+      PHPUNIT_FILE=/docker-files/phpunitv10.xml
+    else
+      PHPUNIT_FILE=/docker-files/phpunit.xml
+    fi
 fi
 echo "Using PHPUnit file: $PHPUNIT_FILE"
 


### PR DESCRIPTION
Details of what I have encountered can be seen here https://github.com/magento/magento2/issues/39907

But in short, annotations are not working in 2.4.8 because of the changes to the phpunit event subscription system.

```php
/**
 * @magentoAdminConfigFixture some/config/value 1
 */
```

After speaking with @michielgerritsen he [suggests](https://github.com/michielgerritsen/magento2-extension-integration-test/commit/c15ada83f77fb7cceb421f6a4395a52c3292bad9) its because we're using an old phpunit.xml, and basing off a fresh M2 installation could be the way to go.

I've had a look at the code and it seems like we're pulling in the phpunit 9 series XML, and trying to run it against the phpunit 10 series code, which has different event system handling.

I do not know how to test this fully, without getting the docker images built etc ?
