### PR TITLE
Attempt to use phpunit 10 compatible event system for PHP Unit testing

### DIFF
--- a/magento-unit-tests/docker-files/phpunitv10.xml
+++ b/magento-unit-tests/docker-files/phpunitv10.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.2/phpunit.xsd"
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="./framework/bootstrap.php"
+         stderr="true"
+>
+    <testsuites>
+        <testsuite name="UnitTests">
+            <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/Test/Unit</directory>
+            <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/tests/Unit</directory>
+            <directory suffix="Test.php">../../../vendor/%COMPOSER_NAME%/tests/unit</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="date.timezone" value="America/Los_Angeles"/>
+        <ini name="xdebug.max_nesting_level" value="200"/>
+    </php>
+</phpunit>

--- a/magento-unit-tests/entrypoint.sh
+++ b/magento-unit-tests/entrypoint.sh
@@ -54,14 +54,17 @@ COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist --no-interaction --no-pr
 echo "Determine which phpunit.xml file to use"
 
 echo "Trying phpunit.xml file $PHPUNIT_FILE"
-if [[ ! -z "$PHPUNIT_FILE" && ! -f "$PHPUNIT_FILE" ]] ; then
+if [[ ! -z "$PHPUNIT_FILE" ]] ; then
     PHPUNIT_FILE=${GITHUB_WORKSPACE}/${PHPUNIT_FILE}
 fi
 
 if [[ ! -f "$PHPUNIT_FILE" ]] ; then
-    PHPUNIT_FILE=/docker-files/phpunit.xml
+    if [[ "$MAGENTO_VERSION" == 2.4.8* ]]; then
+      PHPUNIT_FILE=/docker-files/phpunitv10.xml
+    else
+      PHPUNIT_FILE=/docker-files/phpunit.xml
+    fi
 fi
-
 echo "Using PHPUnit file: $PHPUNIT_FILE"
 echo "Prepare for unit tests"
 cd $MAGENTO_ROOT


### PR DESCRIPTION
Just as @convenient found issues when [trying to ran Integration tests](https://github.com/extdn/github-actions-m2/pull/129) on PHP Unit v10, I saw the same exact issue on Unit Testing. For my case the only thing I was able to test was the PHP Unit XML and it works for me.

Error:
```
There was 1 PHPUnit test runner warning:

1) Test results may not be as expected because the XML configuration file did not pass validation:

  Line 8:
  - Element 'filter': This element is not expected.
```

I'm glad to contribute, and I'd like to say thanks for all of your work for this community.