### PR TITLE
Remove xdebug.max_nesting_level ini setting from PHPUnit config

### DIFF
--- a/magento-integration-tests/docker-files/phpunit.xml
+++ b/magento-integration-tests/docker-files/phpunit.xml
@@ -30,7 +30,6 @@
         <includePath>.</includePath>
         <includePath>testsuite</includePath>
         <ini name="date.timezone" value="America/Los_Angeles"/>
-        <ini name="xdebug.max_nesting_level" value="200"/>
         <ini name="memory_limit" value="-1"/>
         <const name="TESTS_INSTALL_CONFIG_FILE" value="etc/install-config-mysql.php"/>
         <const name="TESTS_POST_INSTALL_SETUP_COMMAND_CONFIG_FILE" value="etc/post-install-setup-command-config.php"/>

--- a/magento-integration-tests/docker-files/phpunitv10.xml
+++ b/magento-integration-tests/docker-files/phpunitv10.xml
@@ -31,7 +31,6 @@
         <includePath>.</includePath>
         <includePath>testsuite</includePath>
         <ini name="date.timezone" value="America/Los_Angeles"/>
-        <ini name="xdebug.max_nesting_level" value="200"/>
         <ini name="memory_limit" value="-1"/>
         <!-- Local XML configuration file ('.dist' extension will be added, if the specified file doesn't exist) -->
         <const name="TESTS_INSTALL_CONFIG_FILE" value="etc/install-config-mysql.php"/>


### PR DESCRIPTION
Description:

  Problem

  When running integration tests, PHPUnit emits the following warning on every run:

  Failed to set "xdebug.max_nesting_level=200":

  This occurs because both phpunit.xml and phpunitv10.xml contain:

  <ini name="xdebug.max_nesting_level" value="200"/>

  However, the Xdebug extension is not installed in any of the integration test Docker images (confirmed across PHP 8.1 through 8.5).
  PHPUnit attempts to apply the ini setting at startup and fails because the extension is not loaded.

  The warning became more visible when the PHP 8.5 image was introduced, as it surfaces on newer PHPUnit versions with stricter output
  handling.

  Fix

  Remove the xdebug.max_nesting_level ini directive from both phpunit.xml and phpunitv10.xml. Since Xdebug is never installed in these
   handling.