### PR TITLE
Remove xdebug.max_nesting_level ini setting from phpunit configs

### DIFF
--- a/magento-quick-integration-tests/docker-files/phpunit.xml
+++ b/magento-quick-integration-tests/docker-files/phpunit.xml
@@ -26,7 +26,6 @@
         <includePath>.</includePath>
         <includePath>testsuite</includePath>
         <ini name="date.timezone" value="America/Los_Angeles"/>
-        <ini name="xdebug.max_nesting_level" value="200"/>
         <const name="TESTS_INSTALL_CONFIG_FILE" value="etc/install-config-mysql.php"/>
         <const name="TESTS_POST_INSTALL_SETUP_COMMAND_CONFIG_FILE" value="etc/post-install-setup-command-config.php"/>
         <const name="TESTS_GLOBAL_CONFIG_FILE" value="etc/config-global.php"/>

--- a/magento-unit-tests/docker-files/phpunit.xml
+++ b/magento-unit-tests/docker-files/phpunit.xml
@@ -24,6 +24,5 @@
     </filter>
     <php>
         <ini name="date.timezone" value="America/Los_Angeles"/>
-        <ini name="xdebug.max_nesting_level" value="200"/>
     </php>
 </phpunit>

--- a/magento-unit-tests/docker-files/phpunitv10.xml
+++ b/magento-unit-tests/docker-files/phpunitv10.xml
@@ -15,6 +15,5 @@
     </testsuites>
     <php>
         <ini name="date.timezone" value="America/Los_Angeles"/>
-        <ini name="xdebug.max_nesting_level" value="200"/>
     </php>
 </phpunit>


### PR DESCRIPTION
This setting was removed in Xdebug 3.x which ships with PHP 8.x, causing PHPUnit to emit a warning that fails CI runs despite all tests passing.