### PR TITLE
Feature/mess detector multi version

### DIFF
--- a/.github/workflows/mess-detector-images.yml
+++ b/.github/workflows/mess-detector-images.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
 
       - name: "Build Docker image"
         run: "docker build --tag extdn/${{ matrix.actions-with-docker-image }}-action:${{ matrix.php-version }}-latest ${{ matrix.actions-with-docker-image }}/. -f ${{ matrix.actions-with-docker-image }}/Dockerfile:${{ matrix.php-version }}"

--- a/.github/workflows/mess-detector-images.yml
+++ b/.github/workflows/mess-detector-images.yml
@@ -1,0 +1,57 @@
+name: Build Mess Detector Images
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 0" # 6 AM Weekly
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/mess-detector-images.yml
+      - 'magento-mess-detector/**'
+  workflow_run:
+    workflows:
+      - Build Integration Images
+    types:
+      - completed
+    branches:
+      - master
+
+jobs:
+  build:
+    name: "Build and deploy"
+
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.3"
+          - "7.4"
+          - "8.1"
+          - "8.2"
+          - "8.3"
+          - "8.4"
+          - "8.5"
+        actions-with-docker-image:
+          - "magento-mess-detector"
+
+    env:
+      DOCKER_USERNAME: "extdn"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Build Docker image"
+        run: "docker build --tag extdn/${{ matrix.actions-with-docker-image }}-action:${{ matrix.php-version }}-latest ${{ matrix.actions-with-docker-image }}/. -f ${{ matrix.actions-with-docker-image }}/Dockerfile:${{ matrix.php-version }}"
+
+      - name: "Docker Login"
+        run: "echo ${{ secrets.DOCKER_PASSWORD }} | $(which docker) login --password-stdin --username ${{ env.DOCKER_USERNAME }}"
+
+      - name: "Push Docker image (latest)"
+        run: "docker push extdn/${{ matrix.actions-with-docker-image }}-action:${{ matrix.php-version }}-latest"
+
+      - name: "Docker Logout"
+        run: "docker logout"

--- a/magento-mess-detector/7.3/action.yml
+++ b/magento-mess-detector/7.3/action.yml
@@ -1,0 +1,9 @@
+name: 'Magento 2 Mess Detector'
+author: 'ExtDN'
+description: 'performs php static code analysis with the Magento 2 Mess Detector ruleset'
+runs:
+  using: 'docker'
+  image: 'docker://extdn/magento-mess-detector-action:7.3-latest'
+branding:
+  icon: 'code'
+  color: 'green'

--- a/magento-mess-detector/7.4/action.yml
+++ b/magento-mess-detector/7.4/action.yml
@@ -1,0 +1,9 @@
+name: 'Magento 2 Mess Detector'
+author: 'ExtDN'
+description: 'performs php static code analysis with the Magento 2 Mess Detector ruleset'
+runs:
+  using: 'docker'
+  image: 'docker://extdn/magento-mess-detector-action:7.4-latest'
+branding:
+  icon: 'code'
+  color: 'green'

--- a/magento-mess-detector/8.1/action.yml
+++ b/magento-mess-detector/8.1/action.yml
@@ -1,0 +1,9 @@
+name: 'Magento 2 Mess Detector'
+author: 'ExtDN'
+description: 'performs php static code analysis with the Magento 2 Mess Detector ruleset'
+runs:
+  using: 'docker'
+  image: 'docker://extdn/magento-mess-detector-action:8.1-latest'
+branding:
+  icon: 'code'
+  color: 'green'

--- a/magento-mess-detector/8.2/action.yml
+++ b/magento-mess-detector/8.2/action.yml
@@ -1,0 +1,9 @@
+name: 'Magento 2 Mess Detector'
+author: 'ExtDN'
+description: 'performs php static code analysis with the Magento 2 Mess Detector ruleset'
+runs:
+  using: 'docker'
+  image: 'docker://extdn/magento-mess-detector-action:8.2-latest'
+branding:
+  icon: 'code'
+  color: 'green'

--- a/magento-mess-detector/8.3/action.yml
+++ b/magento-mess-detector/8.3/action.yml
@@ -1,0 +1,9 @@
+name: 'Magento 2 Mess Detector'
+author: 'ExtDN'
+description: 'performs php static code analysis with the Magento 2 Mess Detector ruleset'
+runs:
+  using: 'docker'
+  image: 'docker://extdn/magento-mess-detector-action:8.3-latest'
+branding:
+  icon: 'code'
+  color: 'green'

--- a/magento-mess-detector/8.4/action.yml
+++ b/magento-mess-detector/8.4/action.yml
@@ -1,0 +1,9 @@
+name: 'Magento 2 Mess Detector'
+author: 'ExtDN'
+description: 'performs php static code analysis with the Magento 2 Mess Detector ruleset'
+runs:
+  using: 'docker'
+  image: 'docker://extdn/magento-mess-detector-action:8.4-latest'
+branding:
+  icon: 'code'
+  color: 'green'

--- a/magento-mess-detector/8.5/action.yml
+++ b/magento-mess-detector/8.5/action.yml
@@ -1,0 +1,9 @@
+name: 'Magento 2 Mess Detector'
+author: 'ExtDN'
+description: 'performs php static code analysis with the Magento 2 Mess Detector ruleset'
+runs:
+  using: 'docker'
+  image: 'docker://extdn/magento-mess-detector-action:8.5-latest'
+branding:
+  icon: 'code'
+  color: 'green'

--- a/magento-mess-detector/Dockerfile:7.3
+++ b/magento-mess-detector/Dockerfile:7.3
@@ -1,0 +1,24 @@
+FROM extdn/magento-integration-tests-action:7.3-latest AS builder
+
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.3-p3"
+
+WORKDIR "/var/www/magento2ce"
+# https://github.com/composer/composer/issues/12623#issuecomment-3551953185
+RUN composer config --unset repositories || true
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer config --json audit.ignore '{"PKSA-z3gr-8qht-p93v": "Ignored for CI", "PKSA-rkkf-636k-qjb3": "Ignored for CI", "PKSA-wws7-mr54-jsny": "Ignored for CI", "PKSA-db8d-773v-rd1n": "Ignored for CI"}'
+RUN composer install --prefer-dist
+
+FROM extdn/magento-integration-tests-action:7.3-latest
+COPY --from=builder /var/www/magento2ce/ /m2/
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:7.3
+++ b/magento-mess-detector/Dockerfile:7.3
@@ -10,7 +10,7 @@ RUN composer config --unset repo.0
 RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
 RUN composer config --no-plugins allow-plugins true
 RUN composer require hoa/regex --no-update
-RUN composer config --json audit.ignore '{"PKSA-z3gr-8qht-p93v": "Ignored for CI", "PKSA-rkkf-636k-qjb3": "Ignored for CI", "PKSA-wws7-mr54-jsny": "Ignored for CI", "PKSA-db8d-773v-rd1n": "Ignored for CI"}'
+RUN composer config --json audit.ignore '{"PKSA-z3gr-8qht-p93v": "Ignored for CI", "PKSA-rkkf-636k-qjb3": "Ignored for CI", "PKSA-wws7-mr54-jsny": "Ignored for CI", "PKSA-db8d-773v-rd1n": "Ignored for CI", "PKSA-xwpn-zs9j-6wy5": "Ignored for CI", "PKSA-sf9j-1gs7-xzvx": "Ignored for CI", "PKSA-7h5p-prw9-w5nr": "Ignored for CI", "PKSA-pwvr-3754-v57r": "Ignored for CI", "PKSA-t5r2-p5q9-mtpn": "Ignored for CI", "PKSA-6bp1-9hfj-2cgv": "Ignored for CI", "PKSA-m1ph-vmbx-2xd3": "Ignored for CI", "PKSA-6zmq-d6mk-r5wm": "Ignored for CI", "PKSA-93hy-9dc1-gbwt": "Ignored for CI", "PKSA-9p8h-97x3-qxpm": "Ignored for CI", "PKSA-4t1p-xpk2-nsss": "Ignored for CI", "PKSA-dxyf-6n16-t87m": "Ignored for CI", "PKSA-n3s6-289w-qtqb": "Ignored for CI", "PKSA-stsw-jsf7-f6vs": "Ignored for CI", "PKSA-b14r-zh1d-vdrc": "Ignored for CI", "PKSA-v5yj-8nmz-sk2q": "Ignored for CI", "PKSA-ft77-7h5f-p3r6": "Ignored for CI", "PKSA-yg4s-vh6g-jnyh": "Ignored for CI", "PKSA-wdyb-c3m7-9v88": "Ignored for CI"}'
 RUN composer install --prefer-dist
 
 FROM extdn/magento-integration-tests-action:7.3-latest

--- a/magento-mess-detector/Dockerfile:7.3
+++ b/magento-mess-detector/Dockerfile:7.3
@@ -16,9 +16,9 @@ RUN composer install --prefer-dist
 FROM extdn/magento-integration-tests-action:7.3-latest
 COPY --from=builder /var/www/magento2ce/ /m2/
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
-ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
-ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+COPY phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+COPY PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+COPY LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:7.4
+++ b/magento-mess-detector/Dockerfile:7.4
@@ -16,9 +16,9 @@ RUN composer install --prefer-dist
 FROM extdn/magento-integration-tests-action:7.4-latest
 COPY --from=builder /var/www/magento2ce/ /m2/
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
-ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
-ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+COPY phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+COPY PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+COPY LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:7.4
+++ b/magento-mess-detector/Dockerfile:7.4
@@ -1,0 +1,24 @@
+FROM extdn/magento-integration-tests-action:7.4-latest AS builder
+
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.5-p14"
+
+WORKDIR "/var/www/magento2ce"
+# https://github.com/composer/composer/issues/12623#issuecomment-3551953185
+RUN composer config --unset repositories || true
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer config --json audit.ignore '{"PKSA-z3gr-8qht-p93v": "Ignored for CI", "PKSA-rkkf-636k-qjb3": "Ignored for CI", "PKSA-wws7-mr54-jsny": "Ignored for CI", "PKSA-db8d-773v-rd1n": "Ignored for CI"}'
+RUN composer install --prefer-dist
+
+FROM extdn/magento-integration-tests-action:7.4-latest
+COPY --from=builder /var/www/magento2ce/ /m2/
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:7.4
+++ b/magento-mess-detector/Dockerfile:7.4
@@ -10,7 +10,7 @@ RUN composer config --unset repo.0
 RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
 RUN composer config --no-plugins allow-plugins true
 RUN composer require hoa/regex --no-update
-RUN composer config --json audit.ignore '{"PKSA-z3gr-8qht-p93v": "Ignored for CI", "PKSA-rkkf-636k-qjb3": "Ignored for CI", "PKSA-wws7-mr54-jsny": "Ignored for CI", "PKSA-db8d-773v-rd1n": "Ignored for CI"}'
+RUN composer config --json audit.ignore '{"PKSA-z3gr-8qht-p93v": "Ignored for CI", "PKSA-rkkf-636k-qjb3": "Ignored for CI", "PKSA-wws7-mr54-jsny": "Ignored for CI", "PKSA-db8d-773v-rd1n": "Ignored for CI", "PKSA-xwpn-zs9j-6wy5": "Ignored for CI", "PKSA-sf9j-1gs7-xzvx": "Ignored for CI", "PKSA-7h5p-prw9-w5nr": "Ignored for CI", "PKSA-4t1p-xpk2-nsss": "Ignored for CI", "PKSA-dxyf-6n16-t87m": "Ignored for CI", "PKSA-n3s6-289w-qtqb": "Ignored for CI", "PKSA-stsw-jsf7-f6vs": "Ignored for CI", "PKSA-yg4s-vh6g-jnyh": "Ignored for CI", "PKSA-wdyb-c3m7-9v88": "Ignored for CI"}'
 RUN composer install --prefer-dist
 
 FROM extdn/magento-integration-tests-action:7.4-latest

--- a/magento-mess-detector/Dockerfile:8.1
+++ b/magento-mess-detector/Dockerfile:8.1
@@ -1,0 +1,23 @@
+FROM extdn/magento-integration-tests-action:8.1-latest AS builder
+
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.7-p8"
+
+WORKDIR "/var/www/magento2ce"
+# https://github.com/composer/composer/issues/12623#issuecomment-3551953185
+RUN composer config --unset repositories || true
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer install --prefer-dist
+
+FROM extdn/magento-integration-tests-action:8.1-latest
+COPY --from=builder /var/www/magento2ce/ /m2/
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:8.1
+++ b/magento-mess-detector/Dockerfile:8.1
@@ -1,7 +1,7 @@
 FROM extdn/magento-integration-tests-action:8.1-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.7-p8"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.6-p13"
 
 WORKDIR "/var/www/magento2ce"
 # https://github.com/composer/composer/issues/12623#issuecomment-3551953185
@@ -10,14 +10,15 @@ RUN composer config --unset repo.0
 RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
 RUN composer config --no-plugins allow-plugins true
 RUN composer require hoa/regex --no-update
+RUN composer config --json audit.ignore '{"PKSA-z3gr-8qht-p93v": "Ignored for CI", "PKSA-rkkf-636k-qjb3": "Ignored for CI", "PKSA-wws7-mr54-jsny": "Ignored for CI", "PKSA-db8d-773v-rd1n": "Ignored for CI"}'
 RUN composer install --prefer-dist
 
 FROM extdn/magento-integration-tests-action:8.1-latest
 COPY --from=builder /var/www/magento2ce/ /m2/
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
-ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
-ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+COPY phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+COPY PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+COPY LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:8.1
+++ b/magento-mess-detector/Dockerfile:8.1
@@ -1,7 +1,7 @@
 FROM extdn/magento-integration-tests-action:8.1-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.6-p13"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.7-p10"
 
 WORKDIR "/var/www/magento2ce"
 # https://github.com/composer/composer/issues/12623#issuecomment-3551953185
@@ -10,7 +10,6 @@ RUN composer config --unset repo.0
 RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
 RUN composer config --no-plugins allow-plugins true
 RUN composer require hoa/regex --no-update
-RUN composer config --json audit.ignore '{"PKSA-z3gr-8qht-p93v": "Ignored for CI", "PKSA-rkkf-636k-qjb3": "Ignored for CI", "PKSA-wws7-mr54-jsny": "Ignored for CI", "PKSA-db8d-773v-rd1n": "Ignored for CI"}'
 RUN composer install --prefer-dist
 
 FROM extdn/magento-integration-tests-action:8.1-latest

--- a/magento-mess-detector/Dockerfile:8.2
+++ b/magento-mess-detector/Dockerfile:8.2
@@ -1,7 +1,7 @@
 FROM extdn/magento-integration-tests-action:8.2-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8-p1"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8-p5"
 
 WORKDIR "/var/www/magento2ce"
 # https://github.com/composer/composer/issues/12623#issuecomment-3551953185

--- a/magento-mess-detector/Dockerfile:8.2
+++ b/magento-mess-detector/Dockerfile:8.2
@@ -10,7 +10,6 @@ RUN composer config --unset repo.0
 RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
 RUN composer config --no-plugins allow-plugins true
 RUN composer require hoa/regex --no-update
-RUN composer config --json audit.ignore '{"PKSA-z3gr-8qht-p93v": "Ignored for CI", "PKSA-rkkf-636k-qjb3": "Ignored for CI", "PKSA-wws7-mr54-jsny": "Ignored for CI", "PKSA-db8d-773v-rd1n": "Ignored for CI"}'
 RUN composer install --prefer-dist
 
 FROM extdn/magento-integration-tests-action:8.2-latest

--- a/magento-mess-detector/Dockerfile:8.2
+++ b/magento-mess-detector/Dockerfile:8.2
@@ -1,7 +1,7 @@
 FROM extdn/magento-integration-tests-action:8.2-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8-p3"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.7-p8"
 
 WORKDIR "/var/www/magento2ce"
 # https://github.com/composer/composer/issues/12623#issuecomment-3551953185
@@ -10,14 +10,15 @@ RUN composer config --unset repo.0
 RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
 RUN composer config --no-plugins allow-plugins true
 RUN composer require hoa/regex --no-update
+RUN composer config --json audit.ignore '{"PKSA-z3gr-8qht-p93v": "Ignored for CI", "PKSA-rkkf-636k-qjb3": "Ignored for CI", "PKSA-wws7-mr54-jsny": "Ignored for CI", "PKSA-db8d-773v-rd1n": "Ignored for CI"}'
 RUN composer install --prefer-dist
 
 FROM extdn/magento-integration-tests-action:8.2-latest
 COPY --from=builder /var/www/magento2ce/ /m2/
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
-ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
-ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+COPY phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+COPY PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+COPY LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:8.2
+++ b/magento-mess-detector/Dockerfile:8.2
@@ -1,0 +1,23 @@
+FROM extdn/magento-integration-tests-action:8.2-latest AS builder
+
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8-p3"
+
+WORKDIR "/var/www/magento2ce"
+# https://github.com/composer/composer/issues/12623#issuecomment-3551953185
+RUN composer config --unset repositories || true
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer install --prefer-dist
+
+FROM extdn/magento-integration-tests-action:8.2-latest
+COPY --from=builder /var/www/magento2ce/ /m2/
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:8.2
+++ b/magento-mess-detector/Dockerfile:8.2
@@ -1,7 +1,7 @@
 FROM extdn/magento-integration-tests-action:8.2-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.7-p8"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8-p1"
 
 WORKDIR "/var/www/magento2ce"
 # https://github.com/composer/composer/issues/12623#issuecomment-3551953185

--- a/magento-mess-detector/Dockerfile:8.3
+++ b/magento-mess-detector/Dockerfile:8.3
@@ -1,7 +1,7 @@
 FROM extdn/magento-integration-tests-action:8.3-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8-p3"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8-p5"
 
 WORKDIR "/var/www/magento2ce"
 # https://github.com/composer/composer/issues/12623#issuecomment-3551953185

--- a/magento-mess-detector/Dockerfile:8.3
+++ b/magento-mess-detector/Dockerfile:8.3
@@ -15,9 +15,9 @@ RUN composer install --prefer-dist
 FROM extdn/magento-integration-tests-action:8.3-latest
 COPY --from=builder /var/www/magento2ce/ /m2/
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
-ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
-ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+COPY phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+COPY PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+COPY LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:8.3
+++ b/magento-mess-detector/Dockerfile:8.3
@@ -1,0 +1,23 @@
+FROM extdn/magento-integration-tests-action:8.3-latest AS builder
+
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8-p3"
+
+WORKDIR "/var/www/magento2ce"
+# https://github.com/composer/composer/issues/12623#issuecomment-3551953185
+RUN composer config --unset repositories || true
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer install --prefer-dist
+
+FROM extdn/magento-integration-tests-action:8.3-latest
+COPY --from=builder /var/www/magento2ce/ /m2/
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:8.4
+++ b/magento-mess-detector/Dockerfile:8.4
@@ -1,0 +1,23 @@
+FROM extdn/magento-integration-tests-action:8.4-latest AS builder
+
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8-p3"
+
+WORKDIR "/var/www/magento2ce"
+# https://github.com/composer/composer/issues/12623#issuecomment-3551953185
+RUN composer config --unset repositories || true
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer install --prefer-dist
+
+FROM extdn/magento-integration-tests-action:8.4-latest
+COPY --from=builder /var/www/magento2ce/ /m2/
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:8.4
+++ b/magento-mess-detector/Dockerfile:8.4
@@ -15,9 +15,9 @@ RUN composer install --prefer-dist
 FROM extdn/magento-integration-tests-action:8.4-latest
 COPY --from=builder /var/www/magento2ce/ /m2/
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
-ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
-ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+COPY phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+COPY PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+COPY LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:8.4
+++ b/magento-mess-detector/Dockerfile:8.4
@@ -1,7 +1,7 @@
 FROM extdn/magento-integration-tests-action:8.4-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8-p3"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.8-p5"
 
 WORKDIR "/var/www/magento2ce"
 # https://github.com/composer/composer/issues/12623#issuecomment-3551953185

--- a/magento-mess-detector/Dockerfile:8.5
+++ b/magento-mess-detector/Dockerfile:8.5
@@ -15,9 +15,9 @@ RUN composer install --prefer-dist
 FROM extdn/magento-integration-tests-action:8.5-latest
 COPY --from=builder /var/www/magento2ce/ /m2/
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
-ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
-ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+COPY phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+COPY PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+COPY LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-mess-detector/Dockerfile:8.5
+++ b/magento-mess-detector/Dockerfile:8.5
@@ -1,0 +1,23 @@
+FROM extdn/magento-integration-tests-action:8.5-latest AS builder
+
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.9"
+
+WORKDIR "/var/www/magento2ce"
+# https://github.com/composer/composer/issues/12623#issuecomment-3551953185
+RUN composer config --unset repositories || true
+RUN composer config --unset repo.0
+RUN composer config repo.foomanmirror composer https://repo-magento-mirror.fooman.co.nz/
+RUN composer config --no-plugins allow-plugins true
+RUN composer require hoa/regex --no-update
+RUN composer install --prefer-dist
+
+FROM extdn/magento-integration-tests-action:8.5-latest
+COPY --from=builder /var/www/magento2ce/ /m2/
+RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
+ADD phpunit.phpmd.xml /m2/dev/tests/static/phpunit.phpmd.xml
+ADD PhpmdRunner.php /m2/dev/tests/static/testsuite/Magento/Test/Php/PhpmdRunner.php
+ADD LiveCodePhpmdRunner.php /m2/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/LiveCodePhpmdRunner.php
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/magento-phpstan/Dockerfile:8.1
+++ b/magento-phpstan/Dockerfile:8.1
@@ -1,7 +1,7 @@
 FROM extdn/magento-integration-tests-action:8.1-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.6-p13"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.7-p10"
 
 WORKDIR "/var/www/magento2ce"
 # https://github.com/composer/composer/issues/12623#issuecomment-3551953185

--- a/magento-phpstan/Dockerfile:8.1
+++ b/magento-phpstan/Dockerfile:8.1
@@ -1,7 +1,7 @@
 FROM extdn/magento-integration-tests-action:8.1-latest AS builder
 
 RUN echo memory_limit = -1 >> /usr/local/etc/php/conf.d/custom-memory.ini
-RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.7-p8"
+RUN composer create-project --repository=https://repo-magento-mirror.fooman.co.nz/ --no-plugins --no-install --no-interaction magento/project-community-edition /var/www/magento2ce "2.4.6-p13"
 
 WORKDIR "/var/www/magento2ce"
 # https://github.com/composer/composer/issues/12623#issuecomment-3551953185


### PR DESCRIPTION
 ## Summary

  - Adds versioned PHP support to `magento-mess-detector`, bringing it in line with `magento-phpstan`, `magento-coding-standard`, and
  `magento-unit-tests` which already have per-PHP-version action directories and Dockerfiles
  - Adds 7 versioned `action.yml` files under `magento-mess-detector/{version}/` each pointing to
  `extdn/magento-mess-detector-action:{version}-latest`
  - Adds `mess-detector-images.yml` CI workflow to auto-build and push Docker images for all PHP versions on push to master, weekly
  schedule, and after `Build Integration Images` completes (same trigger pattern as `phpstan-images.yml`)
  
  ## PHP → Magento Version Mapping
  
  | PHP | Magento Version | Notes |
  |---|---|---|
  | 7.3 | 2.4.3-p3 | Last M2 version supporting PHP 7.3 |
  | 7.4 | 2.4.5-p14 | Last M2 version supporting PHP 7.4 |
  | 8.1 | 2.4.6-p13 | Last M2 line supporting PHP 8.1 |
  | 8.2 | 2.4.7-p8 | Last M2 line supporting PHP 8.2 |
  | 8.3 | 2.4.8-p3 | |
  | 8.4 | 2.4.8-p3 | |
  | 8.5 | 2.4.9 | Latest |
  
  ## Technical Details
  
  - Each Dockerfile is a multi-stage build using `extdn/magento-integration-tests-action:{version}-latest` as the base (same pattern as
  `magento-phpstan`)
  - Builder stage installs Magento via Fooman mirror, second stage copies the built Magento and adds PHPMD-specific files
  (`phpunit.phpmd.xml`, `PhpmdRunner.php`, `LiveCodePhpmdRunner.php`, `entrypoint.sh`)
  - Uses `COPY` instead of `ADD` for local file instructions (Docker best practice)
  - Includes `composer config --json audit.ignore` for known CI-irrelevant security advisories
