### PR TITLE
Ignore otphp security advisories blocking Magento 2.4.6 installs

### DIFF
--- a/magento-integration-tests/entrypoint.sh
+++ b/magento-integration-tests/entrypoint.sh
@@ -91,7 +91,7 @@ echo "Configure Composer audit.block-insecure"
 composer config audit.block-insecure "$BLOCK_INSECURE"
 
 echo "Ignore known security advisories"
-composer config --json audit.ignore '{"PKSA-z3gr-8qht-p93v": "Ignored for CI", "PKSA-rkkf-636k-qjb3": "Ignored for CI", "PKSA-wws7-mr54-jsny": "Ignored for CI", "PKSA-db8d-773v-rd1n": "Ignored for CI"}'
+composer config --json audit.ignore '{"PKSA-z3gr-8qht-p93v": "Ignored for CI", "PKSA-rkkf-636k-qjb3": "Ignored for CI", "PKSA-wws7-mr54-jsny": "Ignored for CI", "PKSA-db8d-773v-rd1n": "Ignored for CI", "PKSA-qv5y-crcz-9nxw": "Ignored for CI", "PKSA-kbc7-dq62-pt7d": "Ignored for CI"}'
 
 echo "Run installation"
 COMPOSER_MEMORY_LIMIT=-1 composer install --no-interaction --no-progress


### PR DESCRIPTION
Integration test jobs for Magento 2.4.5 and 2.4.6 fail during `composer install` with an unresolvable dependency set:

    magento/module-two-factor-auth[1.1.5, ..., 1.1.5-p8] require
    spomky-labs/otphp ^10.0 -> found spomky-labs/otphp[v10.0.0 ... v10.0.3]
    but these were not loaded, because they are affected by security
    advisories ("PKSA-qv5y-crcz-9nxw", "PKSA-kbc7-dq62-pt7d")

Both advisories affect otphp < 11.4.3, and the affected Magento versions pin a two-factor-auth release constrained to `^10.0`, so no permitted version exists and resolution fails outright rather than warning:

    2.4.5-p12 -> security-package 1.1.4-p12 -> tfa 1.1.4-p11 -> otphp ^10.0
    2.4.6-p15 -> security-package 1.1.5-p15 -> tfa 1.1.5-p8  -> otphp ^10.0
    2.4.7-p10 -> security-package 1.1.6-p10 -> tfa 1.1.6-p3  -> otphp ^11.2
    2.4.8-p5  -> security-package 1.1.7-p5  -> tfa 1.1.7     -> otphp ^11.2
    2.4.9     -> security-package 1.1.8     -> tfa 1.1.8     -> otphp ^11.2

This is why only 2.4.5 and 2.4.6 are affected; 2.4.7+ resolve to otphp 11.4.3/11.5.0 and are unaffected. The break is time-triggered by the advisories being published upstream, not by any change here: the same jobs passed in May 2026 and fail in August 2026 with no relevant commit between them.

Add the two advisory IDs to the existing `audit.ignore` allowlist.

Verified in extdn/magento-integration-tests-action:8.2-latest (PHP 8.2.33, Composer 2.10.2) against 2.4.6-p15:

  - current 4-ID list                -> exit 2, resolution fails
  - this 6-ID list via audit.ignore  -> exit 0, locks otphp v10.0.3
  - same 6 IDs via policy.advisories.ignore-id -> exit 0

Composer 2.10 deprecated most of the `audit` config in favour of `policy`, and the new `policy.advisories.ignore-id` key works equally well here. `audit.ignore` is kept for now because it is still honoured in 2.10.2 and keeps this a one-line change; migrating the whole block to `policy.*` is worth doing separately.