### PR TITLE
Support PHPMD 3 in the mess detector runner

### DIFF
--- a/magento-mess-detector/LiveCodePhpmdRunner.php
+++ b/magento-mess-detector/LiveCodePhpmdRunner.php
@@ -56,6 +56,27 @@ class LiveCodePhpmdRunner implements ToolInterface
      */
     public function run(array $whiteList)
     {
+        $command = $this->createCommand();
+
+        // PHPMD 3 turned the command into a Symfony console command and dropped the array based
+        // CommandLineOptions constructor. Images that build Magento 2.4.7 still install PHPMD 2
+        // (it pins phpmd/phpmd ^2.12), so both APIs have to keep working.
+        if ($command instanceof \Symfony\Component\Console\Command\Command) {
+            $input = new \Symfony\Component\Console\Input\ArrayInput(
+                [
+                    'paths' => explode(',', $this->getSourceCodePath($whiteList)),
+                    '--format' => 'github',
+                    '--ruleset' => [$this->rulesetFile],
+                    '--reportfile-github' => $this->reportFile,
+                    '--suffixes' => ['php'],
+                    '--exclude' => ['vendor/', 'tmp/', 'var/', 'generated/', '.git/', '.idea/'],
+                ],
+                $command->getDefinition()
+            );
+
+            return $command->run($input, new \Symfony\Component\Console\Output\NullOutput());
+        }
+
         $commandLineArguments = [
             'run_file_mock', //emulate script name in console arguments
             $this->getSourceCodePath($whiteList),
@@ -71,9 +92,23 @@ class LiveCodePhpmdRunner implements ToolInterface
 
         $options = new \PHPMD\TextUI\CommandLineOptions($commandLineArguments);
 
-        $command = new \PHPMD\TextUI\Command();
-
         return $command->run($options, new \PHPMD\RuleSetFactory());
+    }
+
+    /**
+     * PHPMD 2.15 made the command require a \PHPMD\Console\Output, PHPMD 3 takes no arguments.
+     *
+     * @return \PHPMD\TextUI\Command
+     */
+    private function createCommand()
+    {
+        $constructor = (new \ReflectionClass(\PHPMD\TextUI\Command::class))->getConstructor();
+
+        if ($constructor !== null && $constructor->getNumberOfRequiredParameters() > 0) {
+            return new \PHPMD\TextUI\Command(new \PHPMD\Console\NullOutput());
+        }
+
+        return new \PHPMD\TextUI\Command();
     }
 
     private function getSourceCodePath($whiteList): string

--- a/magento-mess-detector/PhpmdRunner.php
+++ b/magento-mess-detector/PhpmdRunner.php
@@ -60,7 +60,7 @@ class PhpmdRunner extends \PHPUnit\Framework\TestCase
         }
 
         $this->assertEquals(
-            Command::EXIT_SUCCESS,
+            $this->getSuccessExitCode(),
             $result,
             "PHP Code Mess has found error(s):" . PHP_EOL . $output
         );
@@ -69,6 +69,16 @@ class PhpmdRunner extends \PHPUnit\Framework\TestCase
         if (file_exists($reportFile)) {
             unlink($reportFile);
         }
+    }
+
+    /**
+     * PHPMD 3 renamed Command::EXIT_SUCCESS to Command::SUCCESS.
+     *
+     * @return int
+     */
+    private function getSuccessExitCode(): int
+    {
+        return defined(Command::class . '::EXIT_SUCCESS') ? Command::EXIT_SUCCESS : Command::SUCCESS;
     }
 
 }


### PR DESCRIPTION
PHPMD 3 changed how the command is called: it is now a Symfony console command taking an InputInterface, instead of the old array based CommandLineOptions. The runner still used the old call, so the job crashed with a TypeError before analysing anything.

The images do not all carry the same PHPMD, so the runner now checks what is installed and calls it accordingly:

- PHP 8.1 image builds Magento 2.4.7, which pins phpmd/phpmd ^2.12 -> PHPMD 2
- PHP 8.2-8.4 images build Magento 2.4.8-p5 -> PHPMD 3
- PHP 8.5 image builds Magento 2.4.9 -> PHPMD 3

Two related breakages are fixed at the same time:

- PHPMD 2.15 made Command::__construct() require a \PHPMD\Console\Output. The runner passed no argument, so the PHP 8.1 image already failed with an ArgumentCountError, independently of PHPMD 3. The command is now built based on what the installed version expects.
- PHPMD 3 renamed Command::EXIT_SUCCESS to Command::SUCCESS, which would have broken the assertion right after the first fix.

Verified against the real images, on a clean module and on a file with four deliberate violations, to confirm the job both passes and still reports findings in the github annotation format:

  image  Magento     PHPMD    clean    4 planted violations
  8.1    2.4.7-p10   2.15.0   passes   all 4 reported
  8.4    2.4.8-p5    3.0.0    passes   all 4 reported
  8.5    2.4.9       3.0.0    passes   all 4 reported